### PR TITLE
feat: add verify_webhook_signature

### DIFF
--- a/blockfrost/__init__.py
+++ b/blockfrost/__init__.py
@@ -2,3 +2,4 @@ from blockfrost.api import BlockFrostApi
 from blockfrost.ipfs import BlockFrostIPFS
 from blockfrost.config import ApiUrls
 from blockfrost.utils import ApiError, Namespace
+from blockfrost.helpers import SignatureVerificationError, verify_webhook_signature

--- a/blockfrost/helpers.py
+++ b/blockfrost/helpers.py
@@ -1,0 +1,68 @@
+import hmac
+import hashlib
+import time
+
+
+class SignatureVerificationError(Exception):
+    def __init__(self, message, header, request_body):
+        self.message = message
+        self.header = header
+        self.request_body = request_body
+        super().__init__(self.message)
+
+
+def get_unix_timestamp():
+    return int(time.time())
+
+
+def verify_webhook_signature(request_body, signature_header, secret, timestamp_tolerance_seconds=600):
+    # Parse signature header
+    # Example of Blockfrost-Signature header: t=1648550558,v1=162381a59040c97d9b323cdfec02facdfce0968490ec1732f5d938334c1eed4e,v1=...)
+    tokens = signature_header.split(',')
+    timestamp = None
+    signatures = []
+    for token in tokens:
+        key, value = token.split('=')
+        if key == 't':
+            timestamp = value
+        elif key == 'v1':
+            signatures.append(value)
+        else:
+            print('Cannot parse part of the Blockfrost-Signature header, key "{}" is not supported by this version of Blockfrost SDK. Please upgrade.'.format(key))
+
+    if timestamp is None or timestamp.isnumeric() is False or len(tokens) < 2:
+        # timestamp and at least one signature must be present
+        raise SignatureVerificationError(
+            'Invalid signature header format.', signature_header, request_body)
+
+    if len(signatures) == 0:
+        # There are no signatures that this version of SDK supports
+        raise SignatureVerificationError(
+            'No signatures with supported version scheme.', signature_header, request_body)
+
+    has_valid_signature = False
+    for signature in signatures:
+        # Recreate signature by concatenating the timestamp with the payload (all in bytes),
+        # then compute HMAC using sha256 and provided secret (webhook auth token)
+        signature_payload = timestamp.encode() + b"." + request_body
+        local_signature = hmac.new(
+            secret.encode(), signature_payload, hashlib.sha256).hexdigest()
+
+        # computed signature should match at least one signature parsed from a signature header
+        if (hmac.compare_digest(signature, local_signature)):
+            has_valid_signature = True
+            break
+
+    if has_valid_signature == False:
+        raise SignatureVerificationError(
+            'No signature matches expected signature for payload.', signature_header, request_body)
+
+    current_timestamp = get_unix_timestamp()
+
+    if (current_timestamp - int(timestamp) > timestamp_tolerance_seconds):
+        # Event is older than timestamp_tolerance_seconds
+        raise SignatureVerificationError(
+            'Signature\'s timestamp is outside of the time tolerance.', signature_header, request_body)
+    else:
+        # Successfully validate the signature only if it is within timestamp_tolerance_seconds tolerance
+        return True

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,78 @@
+import os
+import mock
+import pytest
+from blockfrost import SignatureVerificationError, verify_webhook_signature
+
+request_body = b'{"id":"47668401-c3a4-42d4-bac1-ad46515924a3","webhook_id":"cf68eb9c-635f-415e-a5a8-6233638f28d7","created":1650013856,"type":"block","payload":{"time":1650013853,"height":7126256,"hash":"f49521b67b440e5030adf124aee8f88881b7682ba07acf06c2781405b0f806a4","slot":58447562,"epoch":332,"epoch_slot":386762,"slot_leader":"pool1njjr0zn7uvydjy8067nprgwlyxqnznp9wgllfnag24nycgkda25","size":34617,"tx_count":13,"output":"13403118309871","fees":"4986390","block_vrf":"vrf_vk197w95j9alkwt8l4g7xkccknhn4pqwx65c5saxnn5ej3cpmps72msgpw69d","previous_block":"9e3f5bfc9f0be44cf6e14db9ed5f1efb6b637baff0ea1740bb6711786c724915","next_block":null,"confirmations":0}}'
+success_fixtures_list = [
+    {
+        'description': 'valid signature',
+        'request_body': request_body,
+        'signature_header': 't=1650013856,v1=f4c3bb2a8b0c8e21fa7d5fdada2ee87c9c6f6b0b159cc22e483146917e195c3e',
+        'secret': '59a1eb46-96f4-4f0b-8a03-b4d26e70593a',
+        'current_timestamp_mock': 1650013856 + 1,
+        'result': True
+    },
+    {
+        'description': '2 signatures, one valid and one invalid',
+        'request_body': request_body,
+        'signature_header': 't=1650013856,v1=abc,v1=f4c3bb2a8b0c8e21fa7d5fdada2ee87c9c6f6b0b159cc22e483146917e195c3e',
+        'secret': '59a1eb46-96f4-4f0b-8a03-b4d26e70593a',
+        'current_timestamp_mock': 1650013856 + 1,
+        'result': True
+    }
+]
+
+error_fixtures_list = [
+    {
+        'description': 'throws due to invalid header fromat',
+        'request_body': request_body,
+        'signature_header': 'v1=f4c3bb2a8b0c8e21fa7d5fdada2ee87c9c6f6b0b159cc22e483146917e195c3e',
+        'secret': '59a1eb46-96f4-4f0b-8a03-b4d26e70593a',
+        'current_timestamp_mock': 1650013856 + 1,
+        'result_error': 'Invalid signature header format.'
+    },
+    {
+        'description': 'throws due to sig version not supported by this sdk',
+        'request_body': request_body,
+        'signature_header': 't=1650013856,v42=abc',
+        'secret': '59a1eb46-96f4-4f0b-8a03-b4d26e70593a',
+        'current_timestamp_mock': 1650013856 + 1,
+        'result_error': 'No signatures with supported version scheme.'
+    },
+    {
+        'description': 'throws due to no signature match',
+        'request_body': request_body,
+        'signature_header': 't=1650013856,v1=abc',
+        'secret': '59a1eb46-96f4-4f0b-8a03-b4d26e70593a',
+        'current_timestamp_mock': 1650013856 + 1,
+        'result_error': 'No signature matches expected signature for payload.'
+    },
+    {
+        'description': 'throws due to timestamp out of tolerance zone',
+        'request_body': request_body,
+        'signature_header': 't=1650013856,v1=f4c3bb2a8b0c8e21fa7d5fdada2ee87c9c6f6b0b159cc22e483146917e195c3e',
+        'secret': '59a1eb46-96f4-4f0b-8a03-b4d26e70593a',
+        'current_timestamp_mock': 1650013856 + 7200,
+        'result_error': 'Signature\'s timestamp is outside of the time tolerance.'
+    }
+]
+
+
+@pytest.mark.parametrize("fixture", success_fixtures_list)
+def test_verify_webhook_signature(fixture):
+    with mock.patch('blockfrost.helpers.get_unix_timestamp', return_value=fixture['current_timestamp_mock']):
+        res = verify_webhook_signature(
+            fixture['request_body'], fixture['signature_header'], fixture['secret'])
+        assert res == fixture['result']
+
+
+@pytest.mark.parametrize("fixture", error_fixtures_list)
+def test_verify_webhook_signature_fails(fixture):
+    with mock.patch('blockfrost.helpers.get_unix_timestamp', return_value=fixture['current_timestamp_mock']):
+        with pytest.raises(SignatureVerificationError) as e_info:
+            verify_webhook_signature(
+                fixture['request_body'], fixture['signature_header'], fixture['secret'])
+        assert str(e_info.value) == fixture['result_error']
+        assert e_info.value.header == fixture['signature_header']
+        assert e_info.value.request_body == fixture['request_body']


### PR DESCRIPTION
Hello @mathiasfrohlich! 
In anticipation of new Blockfrost feature Secure Webhooks:tm:, this PR adds new helper function `verify_webhook_signature` to verify that the webhook requests originated from Blockfrost and not some malicious actor.

I have a feeling that the unit tests are not very pythonic, but It's been years since I wrote python and I just don't know any better 😓 . Implementation is mostly ported from javascript https://github.com/blockfrost/blockfrost-js/blob/bfa718db7238942eca7c80053194ee91c0eaf421/src/utils/helpers.ts#L144

The function accepts 4 parameters:
- `request_body`: whole request's body in bytes
- `signature_header`: Blockfrost-Signature header that will be included in every webhook request
- `secret`: webhook auth token that is used to sign the request (user will find it in Blockfrost Dashboard)
- `timestamp_tolerance_seconds`: optional, default 600s. Time window for checking the validity of the signature. If the computed signature matches the signature received in the request, but the timestamp is too old, the signature is considered to be invalid.

If the signature is valid then the function returns `True`. Otherwise It raises `SignatureVerificationError`. The error object has additional fields `header` and `request_body` for debugging purposes.

`verify_webhook_signature` function and `SignatureVerificationError` error should be exported from the package so users will be able to import it in their projects (I have not tested if it is working and I am not sure if some additional python magic is necessary).

Example usage with Flask backend


```python
# Example of Python Flask app with /webhook endpoint
# for processing events sent by Blockfrost Secure Webhooks
from flask import Flask, request, json
from blockfrost import verify_webhook_signature, SignatureVerificationError

SECRET_AUTH_TOKEN = "SECRET-WEBHOOK-AUTH-TOKEN"

app = Flask(__name__)

@app.route('/webhook', methods=['POST'])
def webhook():
    if request.method == 'POST':
        # Validate webhook signature
        request_bytes = request.get_data()
        try:
            verify_webhook_signature(
                request_bytes, request.headers['Blockfrost-Signature'], SECRET_AUTH_TOKEN)
        except SignatureVerificationError as e:
            # for easier debugging you can access passed header and request_body values (e.header, e.request_body)
            print('Webhook signature is invalid.', e)
            return 'Invalid signature', 403
        
        # Get the payload as JSON
        event = request.json

        print('Received request id {}, webhook_id: {}'.format(
            event['id'], event['webhook_id']))

        if event['type'] == "block":
            # process Block event
            print('Received block hash {}'.format(event['payload']['hash']))
        elif event['type'] == "...":
            # truncated
        else:
            # Unexpected event type
            print('Unexpected event type {}'.format(event['type']))

        return 'Webhook received', 200
    else:
        return 'POST Method not supported', 405



if __name__ == "__main__":
    app.run(host='0.0.0.0', port=6666)

```

