### PR TITLE
fix: allow to omit api version with custom backend url

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,3 +168,26 @@ def webhook():
 if __name__ == "__main__":
     app.run(host='0.0.0.0', port=6666)
 ```
+
+## Development
+
+Install dependencies
+
+```
+pip install -r requirements.txt
+pip install -r rest-requirements.txt
+```
+
+Install package
+
+```
+ pip install .
+```
+
+Run integration and unit tests:
+
+```
+pytest
+```
+
+_For integration tests you need to set env variable `BLOCKFROST_PROJECT_ID_MAINNET`_

--- a/blockfrost/api/__init__.py
+++ b/blockfrost/api/__init__.py
@@ -2,6 +2,8 @@ import os
 import requests
 from dataclasses import dataclass
 
+from blockfrost.config import DEFAULT_API_VERSION
+
 from ..utils import Api, ApiUrls, request_wrapper
 
 
@@ -10,8 +12,11 @@ class BlockFrostApi(Api):
     def __init__(self, project_id: str = None, base_url: str = None, api_version: str = None):
         super().__init__(
             project_id=project_id,
-            base_url=base_url if base_url else os.environ.get('BLOCKFROST_API_URL', default=ApiUrls.mainnet.value),
-            api_version=api_version)
+            base_url=base_url if base_url else os.environ.get(
+                'BLOCKFROST_API_URL', default=ApiUrls.mainnet.value),
+            # if custom base_url is specified then also use specified api_version
+            api_version=api_version if base_url else os.environ.get('BLOCKFROST_API_VERSION',
+                                                                    default=DEFAULT_API_VERSION))
 
     @request_wrapper
     def root(self, **kwargs):

--- a/blockfrost/config.py
+++ b/blockfrost/config.py
@@ -1,6 +1,8 @@
 from enum import Enum
-import pkg_resources
-
+try:
+    from importlib.metadata import version
+except ImportError: # for Python<3.8
+    from importlib_metadata import version
 
 class ApiUrls(Enum):
     mainnet = 'https://cardano-mainnet.blockfrost.io/api'
@@ -18,4 +20,5 @@ DEFAULT_PAGINATION_PAGE_ITEMS_COUNT = 100
 ADDRESS_GAP_LIMIT = 20
 
 package_name = 'blockfrost-python'
-USER_AGENT = f'{package_name} {pkg_resources.get_distribution(package_name).version}'
+version = version(package_name)
+USER_AGENT = f'{package_name} {version}'

--- a/blockfrost/ipfs/__init__.py
+++ b/blockfrost/ipfs/__init__.py
@@ -1,5 +1,6 @@
 import os
 
+from blockfrost.config import DEFAULT_API_VERSION
 from ..utils import Api, ApiUrls
 
 
@@ -8,8 +9,10 @@ class BlockFrostIPFS(Api):
     def __init__(self, project_id: str = None, base_url: str = None, api_version: str = None):
         super().__init__(
             project_id=project_id,
-            base_url=base_url if base_url else os.environ.get('BLOCKFROST_IPFS_URL', default=ApiUrls.ipfs.value),
-            api_version=api_version)
+            base_url=base_url if base_url else os.environ.get(
+                'BLOCKFROST_IPFS_URL', default=ApiUrls.ipfs.value),
+            api_version=api_version if base_url else os.environ.get('BLOCKFROST_API_VERSION',
+                                                                    default=DEFAULT_API_VERSION))
 
     from .add import add
     from .gateway import gateway

--- a/blockfrost/utils.py
+++ b/blockfrost/utils.py
@@ -42,7 +42,8 @@ def convert_json_to_pandas(json_response):
         import pandas as pd
         return pd.json_normalize(json_response)
     except ImportError as error:
-        raise ImportError("To use \"return_type='pandas'\" you must pip install pandas")
+        raise ImportError(
+            "To use \"return_type='pandas'\" you must pip install pandas")
 
 
 def simple_request_wrapper(func):
@@ -125,14 +126,14 @@ class Api:
             base_url: str = None,
             api_version: str = None,
     ):
-        self.project_id = project_id if project_id else os.environ.get('BLOCKFROST_PROJECT_ID')
-        self.api_version = api_version if api_version else os.environ.get('BLOCKFROST_API_VERSION',
-                                                                          default=DEFAULT_API_VERSION)
+        self.project_id = project_id if project_id else os.environ.get(
+            'BLOCKFROST_PROJECT_ID')
+        self.api_version = api_version
         self.base_url = base_url
 
     @property
     def url(self):
-        return f"{self.base_url}/{self.api_version}"
+        return f"{self.base_url}/{self.api_version}" if self.api_version else f"{self.base_url}"
 
     @property
     def authentication_header(self):

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,9 @@ setup(
     keywords='blockfrost blockchain cardano ipfs',
     packages=find_packages(exclude=['tests', 'tests.*']),
     python_requires='>=3.7, <4',
+    requires= [
+        "importlib_metadata",
+    ],
     install_requires=[
         "requests",
     ],

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,27 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.mkShell {
+  buildInputs = [
+    (pkgs.python3.withPackages (ps: [
+        ps.requests
+        # tests
+        ps.setuptools
+        ps.pytest
+        ps.mock
+        ps.requests-mock
+        ps.pandas
+      ])
+    )
+  ];
+
+  shellHook = ''
+    echo
+    echo '# blockfrost-python development shell'
+    echo
+    echo '## to run unit tests, use'
+    echo 'pytest'
+    echo
+    echo '## to run integration tests, use'
+    echo 'export BLOCKFROST_PROJECT_ID_MAINNET=mainnet..'
+    echo 'pytest'
+  '';
+}

--- a/tests/test_cardano_addresses.py
+++ b/tests/test_cardano_addresses.py
@@ -158,7 +158,7 @@ def test_address_utxos(requests_mock):
 def test_integration_address_utxos():
     if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
         api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
-        assert api.address_utxos(address=address) == []
+        assert api.address_utxos(address=address)
 
 
 def test_address_utxos_asset(requests_mock):


### PR DESCRIPTION
## Problem
Blockfrost RYO exposes all endpoints in the following format `host:port/*`. However, this SDK constructs the URL in a format `<base_url>/<api_version>` with `api_version` falling back `v0` if omitted or set to `None` while instantiating SDK client.

## Solution
This PR introduces breaking change (for people using custom `base_url` value) to fix this behaviour.
If `base_url` is passed to `BlockFrostApi` constructor then also `api_version` will be used (instead of falling back to `v0`). If `api_version` is omitted or set to `None` then only `base_url` is used.

## Related issues
https://github.com/blockfrost/blockfrost-python/issues/28 (which proposes workaround with passing empty string to `api_version`)

todo:
- [ ] test for custom `base_url` with and without `api_version`