### PR TITLE
Add new API endpoints for Blockfrost API v0.1.86

### DIFF
--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -11,12 +11,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -16,11 +16,11 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.12"
       - name: Install pypa/build
         run: >
           python -m

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Install dependencies
 
 ```
 pip install -r requirements.txt
-pip install -r rest-requirements.txt
+pip install -r test-requirements.txt
 ```
 
 Install package

--- a/blockfrost/api/__init__.py
+++ b/blockfrost/api/__init__.py
@@ -121,7 +121,8 @@ class BlockFrostApi(Api):
         pool_relays, \
         pool_delegators, \
         pool_blocks, \
-        pool_updates
+        pool_updates, \
+        pool_votes
     from .cardano.transactions import \
         transaction, \
         transaction_utxos, \
@@ -161,6 +162,11 @@ class BlockFrostApi(Api):
         governance_proposal_parameters, \
         governance_proposal_withdrawals, \
         governance_proposal_votes, \
-        governance_proposal_metadata
+        governance_proposal_metadata, \
+        governance_proposal_by_gov_action_id, \
+        governance_proposal_parameters_by_gov_action_id, \
+        governance_proposal_withdrawals_by_gov_action_id, \
+        governance_proposal_votes_by_gov_action_id, \
+        governance_proposal_metadata_by_gov_action_id
     from .cardano.utils import \
         utils_addresses_xpub

--- a/blockfrost/api/__init__.py
+++ b/blockfrost/api/__init__.py
@@ -57,7 +57,9 @@ class BlockFrostApi(Api):
         account_mirs, \
         account_addresses, \
         account_addresses_assets, \
-        account_addresses_total
+        account_addresses_total, \
+        account_utxos, \
+        account_transactions
     from .cardano.addresses import \
         address, \
         address_extended, \
@@ -75,12 +77,14 @@ class BlockFrostApi(Api):
     from .cardano.blocks import \
         block_latest, \
         block_latest_transactions, \
+        block_latest_transactions_cbor, \
         block, \
         block_slot, \
         block_epoch_slot, \
         blocks_next, \
         blocks_previous, \
         block_transactions, \
+        block_transactions_cbor, \
         blocks_addresses
     from .cardano.epochs import \
         epoch_latest, \
@@ -104,7 +108,8 @@ class BlockFrostApi(Api):
         metadata_label_json, \
         metadata_label_cbor
     from .cardano.network import \
-        network
+        network, \
+        network_eras
     from .cardano.pools import \
         pools, \
         pools_extended, \
@@ -131,6 +136,8 @@ class BlockFrostApi(Api):
         transaction_submit, \
         transaction_submit_cbor, \
         transaction_redeemers, \
+        transaction_required_signers, \
+        transaction_cbor, \
         transaction_evaluate, \
         transaction_evaluate_cbor, \
         transaction_evaluate_utxos
@@ -142,5 +149,18 @@ class BlockFrostApi(Api):
         script_redeemers, \
         script_datum, \
         script_datum_cbor
+    from .cardano.governance import \
+        governance_dreps, \
+        governance_drep, \
+        governance_drep_delegators, \
+        governance_drep_metadata, \
+        governance_drep_updates, \
+        governance_drep_votes, \
+        governance_proposals, \
+        governance_proposal, \
+        governance_proposal_parameters, \
+        governance_proposal_withdrawals, \
+        governance_proposal_votes, \
+        governance_proposal_metadata
     from .cardano.utils import \
         utils_addresses_xpub

--- a/blockfrost/api/__init__.py
+++ b/blockfrost/api/__init__.py
@@ -23,7 +23,7 @@ class BlockFrostApi(Api):
         """
         Root endpoint has no other function than to point end users to documentation.
 
-        https://docs.blockfrost.io/#tag/Health/paths/~1/get
+        https://docs.blockfrost.io/#tag/health/GET/
         :param return_type: Optional. "object", "json" or "pandas". Default: "object".
         :type return_type: str
         :returns RootResponse object.

--- a/blockfrost/api/cardano/accounts.py
+++ b/blockfrost/api/cardano/accounts.py
@@ -7,7 +7,7 @@ def accounts(self, stake_address: str, **kwargs):
     """
     Obtain information about a specific networkStake account.
 
-    https://docs.blockfrost.io/#tag/Cardano-Accounts/paths/~1accounts~1{stake_address}/get
+    https://docs.blockfrost.io/#tag/cardano--accounts/GET/accounts/{stake_address}
 
     :param stake_address: Bech32 stake address.
     :type stake_address: str
@@ -29,7 +29,7 @@ def account_rewards(self, stake_address: str, **kwargs):
     """
     Obtain information about the history of a specific account.
 
-    https://docs.blockfrost.io/#tag/Cardano-Accounts/paths/~1accounts~1{stake_address}~1rewards/get
+    https://docs.blockfrost.io/#tag/cardano--accounts/GET/accounts/{stake_address}/rewards
 
     :param stake_address: Bech32 stake address.
     :type stake_address: str
@@ -60,7 +60,7 @@ def account_history(self, stake_address: str, **kwargs):
     """
     Obtain information about the history of a specific account.
 
-    https://docs.blockfrost.io/#tag/Cardano-Accounts/paths/~1accounts~1{stake_address}~1history/get
+    https://docs.blockfrost.io/#tag/cardano--accounts/GET/accounts/{stake_address}/history
 
     :param stake_address: Bech32 stake address.
     :type stake_address: str
@@ -91,7 +91,7 @@ def account_delegations(self, stake_address: str, **kwargs):
     """
     Obtain information about the delegation of a specific account.
 
-    https://docs.blockfrost.io/#tag/Cardano-Accounts/paths/~1accounts~1{stake_address}~1delegations/get
+    https://docs.blockfrost.io/#tag/cardano--accounts/GET/accounts/{stake_address}/delegations
 
     :param stake_address: Bech32 stake address.
     :type stake_address: str
@@ -122,7 +122,7 @@ def account_registrations(self, stake_address: str, **kwargs):
     """
     Obtain information about the registrations and deregistrations of a specific account.
 
-    https://docs.blockfrost.io/#tag/Cardano-Accounts/paths/~1accounts~1{stake_address}~1registrations/get
+    https://docs.blockfrost.io/#tag/cardano--accounts/GET/accounts/{stake_address}/registrations
 
     :param stake_address: Bech32 stake address.
     :type stake_address: str
@@ -153,7 +153,7 @@ def account_withdrawals(self, stake_address: str, **kwargs):
     """
     Obtain information about the withdrawals of a specific account.
 
-    https://docs.blockfrost.io/#tag/Cardano-Accounts/paths/~1accounts~1{stake_address}~1withdrawals/get
+    https://docs.blockfrost.io/#tag/cardano--accounts/GET/accounts/{stake_address}/withdrawals
 
     :param stake_address: Bech32 stake address.
     :type stake_address: str
@@ -184,7 +184,7 @@ def account_mirs(self, stake_address: str, **kwargs):
     """
     Obtain information about the MIRs of a specific account.
 
-    https://docs.blockfrost.io/#tag/Cardano-Accounts/paths/~1accounts~1{stake_address}~1mirs/get
+    https://docs.blockfrost.io/#tag/cardano--accounts/GET/accounts/{stake_address}/mirs
 
     :param stake_address: Bech32 stake address.
     :type stake_address: str
@@ -215,7 +215,7 @@ def account_addresses(self, stake_address: str, **kwargs):
     """
     Obtain information about the addresses of a specific account.
 
-    https://docs.blockfrost.io/#tag/Cardano-Accounts/paths/~1accounts~1{stake_address}~1addresses/get
+    https://docs.blockfrost.io/#tag/cardano--accounts/GET/accounts/{stake_address}/addresses
 
     :param stake_address: Bech32 stake address.
     :type stake_address: str
@@ -248,7 +248,7 @@ def account_addresses_assets(self, stake_address: str, **kwargs):
 
     Be careful, as an account could be part of a mangled address and does not necessarily mean the addresses are owned by user as the account.
 
-    https://docs.blockfrost.io/#tag/Cardano-Accounts/paths/~1accounts~1{stake_address}~1addresses~1assets/get
+    https://docs.blockfrost.io/#tag/cardano--accounts/GET/accounts/{stake_address}/addresses/assets
 
     :param stake_address: Bech32 stake address.
     :type stake_address: str
@@ -279,7 +279,7 @@ def account_utxos(self, stake_address: str, **kwargs):
     """
     Obtain information about UTXOs of a specific account.
 
-    https://docs.blockfrost.io/#tag/Cardano-Accounts/paths/~1accounts~1{stake_address}~1utxos/get
+    https://docs.blockfrost.io/#tag/cardano--accounts/GET/accounts/{stake_address}/utxos
 
     :param stake_address: Bech32 stake address.
     :type stake_address: str
@@ -310,7 +310,7 @@ def account_transactions(self, stake_address: str, **kwargs):
     """
     Obtain information about transactions associated with a specific account.
 
-    https://docs.blockfrost.io/#tag/Cardano-Accounts/paths/~1accounts~1{stake_address}~1transactions/get
+    https://docs.blockfrost.io/#tag/cardano--accounts/GET/accounts/{stake_address}/transactions
 
     :param stake_address: Bech32 stake address.
     :type stake_address: str
@@ -343,7 +343,7 @@ def account_addresses_total(self, stake_address: str, **kwargs):
 
     Be careful, as an account could be part of a mangled address and does not necessarily mean the addresses are owned by user as the account.
 
-    https://docs.blockfrost.io/#tag/Cardano-Addresses/paths/~1accounts~1{stake_address}~1addresses~1total/get
+    https://docs.blockfrost.io/#tag/cardano--addresses/GET/accounts/{stake_address}/addresses/total
 
     :param stake_address: Bech32 address.
     :type stake_address: str

--- a/blockfrost/api/cardano/addresses.py
+++ b/blockfrost/api/cardano/addresses.py
@@ -7,7 +7,7 @@ def address(self, address: str, **kwargs):
     """
     Obtain information about a specific address.
 
-    https://docs.blockfrost.io/#tag/Cardano-Addresses/paths/~1addresses~1{address}/get
+    https://docs.blockfrost.io/#tag/cardano--addresses/GET/addresses/{address}
 
     :param address: Bech32 address.
     :type address: str
@@ -29,7 +29,7 @@ def address_extended(self, address: str, **kwargs):
     """
     Obtain information about a specific address.
 
-    https://docs.blockfrost.io/#tag/Cardano-Addresses/paths/~1addresses~1{address}~1extended/get
+    https://docs.blockfrost.io/#tag/cardano--addresses/GET/addresses/{address}/extended
 
     :param address: Bech32 address.
     :type address: str
@@ -51,7 +51,7 @@ def address_total(self, address: str, **kwargs):
     """
     Obtain details about an address.
 
-    https://docs.blockfrost.io/#tag/Cardano-Addresses/paths/~1addresses~1{address}~1total/get
+    https://docs.blockfrost.io/#tag/cardano--addresses/GET/addresses/{address}/total
 
     :param address: Bech32 address.
     :type address: str
@@ -73,7 +73,7 @@ def address_utxos(self, address: str, **kwargs):
     """
     UTXOs of the address.
 
-    https://docs.blockfrost.io/#tag/Cardano-Addresses/paths/~1addresses~1{address}~1utxos/get
+    https://docs.blockfrost.io/#tag/cardano--addresses/GET/addresses/{address}/utxos
 
     :param address: Bech32 address.
     :type address: str
@@ -104,7 +104,7 @@ def address_utxos_asset(self, address: str, asset: str, **kwargs):
     """
     UTXOs of the address.
 
-    https://docs.blockfrost.io/#tag/Cardano-Addresses/paths/~1addresses~1{address}~1utxos~1{asset}/get
+    https://docs.blockfrost.io/#tag/cardano--addresses/GET/addresses/{address}/utxos/{asset}
 
     :param address: Bech32 address.
     :type address: str
@@ -138,7 +138,7 @@ def address_transactions(self, address: str, from_block: str = None, to_block: s
     """
     Transactions on the address.
 
-    https://docs.blockfrost.io/#tag/Cardano-Addresses/paths/~1addresses~1{address}~1transactions/get
+    https://docs.blockfrost.io/#tag/cardano--addresses/GET/addresses/{address}/transactions
 
     :param address: Bech32 address.
     :type address: str

--- a/blockfrost/api/cardano/assets.py
+++ b/blockfrost/api/cardano/assets.py
@@ -7,7 +7,7 @@ def assets(self, **kwargs):
     """
     List of assets.
 
-    https://docs.blockfrost.io/#tag/Cardano-Assets/paths/~1assets/get
+    https://docs.blockfrost.io/#tag/cardano--assets/GET/assets
 
     :param return_type: Optional. "object", "json" or "pandas". Default: "object".
     :type return_type: str
@@ -36,7 +36,7 @@ def asset(self, asset: str, **kwargs):
     """
     Information about a specific asset
 
-    https://docs.blockfrost.io/#tag/Cardano-Assets/paths/~1assets~1{asset}/get
+    https://docs.blockfrost.io/#tag/cardano--assets/GET/assets/{asset}
 
     :param asset: Concatenation of the policy_id and hex-encoded asset_name.
     :type asset: str
@@ -58,7 +58,7 @@ def asset_history(self, asset: str, **kwargs):
     """
     History of a specific asset
 
-    https://docs.blockfrost.io/#tag/Cardano-Assets/paths/~1assets~1{asset}~1history/get
+    https://docs.blockfrost.io/#tag/cardano--assets/GET/assets/{asset}/history
 
     :param asset: Concatenation of the policy_id and hex-encoded asset_name.
     :type asset: str
@@ -89,7 +89,7 @@ def asset_transactions(self, asset: str, **kwargs):
     """
     List of a specific asset transactions
 
-    https://docs.blockfrost.io/#tag/Cardano-Assets/paths/~1assets~1{asset}~1transactions/get
+    https://docs.blockfrost.io/#tag/cardano--assets/GET/assets/{asset}/transactions
 
     :param asset: Concatenation of the policy_id and hex-encoded asset_name.
     :type asset: str
@@ -120,7 +120,7 @@ def asset_addresses(self, asset: str, **kwargs):
     """
     List of a addresses containing a specific asset
 
-    https://docs.blockfrost.io/#tag/Cardano-Assets/paths/~1assets~1{asset}~1addresses/get
+    https://docs.blockfrost.io/#tag/cardano--assets/GET/assets/{asset}/addresses
 
     :param asset: Concatenation of the policy_id and hex-encoded asset_name.
     :type asset: str
@@ -151,7 +151,7 @@ def assets_policy(self, policy_id: str, **kwargs):
     """
     List of asset minted under a specific policy
 
-    https://docs.blockfrost.io/#tag/Cardano-Assets/paths/~1assets~1policy~1{policy_id}/get
+    https://docs.blockfrost.io/#tag/cardano--assets/GET/assets/policy/{policy_id}
 
     :param policy_id: Specific policy_id.
     :type policy_id: str

--- a/blockfrost/api/cardano/blocks.py
+++ b/blockfrost/api/cardano/blocks.py
@@ -205,6 +205,62 @@ def block_transactions(self, hash_or_number: str, **kwargs):
 
 
 @list_request_wrapper
+def block_latest_transactions_cbor(self, **kwargs):
+    """
+    Return the transactions within the latest block in CBOR format.
+
+    https://docs.blockfrost.io/#tag/Cardano-Blocks/paths/~1blocks~1latest~1txs~1cbor/get
+
+    :param gather_pages: Optional. Default: false. Will collect all pages into one return
+    :type gather_pages: bool
+    :param count: Optional. Default: 100. The number of results displayed on one page.
+    :type count: int
+    :param page: Optional. The page number for listing the results.
+    :type page: int
+    :param order: Optional. "asc" or "desc". Default: "asc".
+    :type order: str
+    :returns A list of objects.
+    :rtype [Namespace]
+    :raises ApiError: If API fails
+    :raises Exception: If the API response is somehow malformed.
+    """
+    return requests.get(
+        url=f"{self.url}/blocks/latest/txs/cbor",
+        params=self.query_parameters(kwargs),
+        headers=self.default_headers
+    )
+
+
+@list_request_wrapper
+def block_transactions_cbor(self, hash_or_number: str, **kwargs):
+    """
+    Return the transactions within the block in CBOR format.
+
+    https://docs.blockfrost.io/#tag/Cardano-Blocks/paths/~1blocks~1{hash_or_number}~1txs~1cbor/get
+
+    :param hash_or_number: Hash or number of the requested block.
+    :type hash_or_number: str
+    :param gather_pages: Optional. Default: false. Will collect all pages into one return
+    :type gather_pages: bool
+    :param count: Optional. Default: 100. The number of results displayed on one page.
+    :type count: int
+    :param page: Optional. The page number for listing the results.
+    :type page: int
+    :param order: Optional. "asc" or "desc". Default: "asc".
+    :type order: str
+    :returns A list of objects.
+    :rtype [Namespace]
+    :raises ApiError: If API fails
+    :raises Exception: If the API response is somehow malformed.
+    """
+    return requests.get(
+        url=f"{self.url}/blocks/{hash_or_number}/txs/cbor",
+        params=self.query_parameters(kwargs),
+        headers=self.default_headers
+    )
+
+
+@list_request_wrapper
 def blocks_addresses(self, hash_or_number: str, **kwargs):
     """
     Return list of addresses affected in the specified block with additional information, sorted by the bech32 address, ascending.

--- a/blockfrost/api/cardano/blocks.py
+++ b/blockfrost/api/cardano/blocks.py
@@ -7,7 +7,7 @@ def block_latest(self, **kwargs):
     """
     Return the latest block available to the backends, also known as the tip of the blockchain.
 
-    https://docs.blockfrost.io/#tag/Cardano-Blocks/paths/~1blocks~1latest/get
+    https://docs.blockfrost.io/#tag/cardano--blocks/GET/blocks/latest
 
     :param return_type: Optional. "object", "json" or "pandas". Default: "object".
     :type return_type: str
@@ -27,7 +27,7 @@ def block_latest_transactions(self, **kwargs):
     """
     Return the transactions within the latest block.
 
-    https://docs.blockfrost.io/#tag/Cardano-Blocks/paths/~1blocks~1latest~1txs/get
+    https://docs.blockfrost.io/#tag/cardano--blocks/GET/blocks/latest/txs
 
     :param gather_pages: Optional. Default: false. Will collect all pages into one return
     :type gather_pages: bool
@@ -54,7 +54,7 @@ def block(self, hash_or_number: str, **kwargs):
     """
     Return the content of a requested block.
 
-    https://docs.blockfrost.io/#tag/Cardano-Blocks/paths/~1blocks~1{hash_or_number}/get
+    https://docs.blockfrost.io/#tag/cardano--blocks/GET/blocks/{hash_or_number}
 
     :param hash_or_number: Hash or number of the requested block.
     :type hash_or_number: str
@@ -76,7 +76,7 @@ def block_slot(self, slot_number: int, **kwargs):
     """
     Return the content of a requested block for a specific slot.
 
-    https://docs.blockfrost.io/#tag/Cardano-Blocks/paths/~1blocks~1slot~1{slot_number}/get
+    https://docs.blockfrost.io/#tag/cardano--blocks/GET/blocks/slot/{slot_number}
 
     :param slot_number: Slot position for requested block.
     :type slot_number: int
@@ -98,7 +98,7 @@ def block_epoch_slot(self, epoch_number: int, slot_number: int, **kwargs):
     """
     Return the content of a requested block for a specific slot in an epoch.
 
-    https://docs.blockfrost.io/#tag/Cardano-Blocks/paths/~1blocks~1epoch~1{epoch_number}~1slot~1{slot_number}/get
+    https://docs.blockfrost.io/#tag/cardano--blocks/GET/blocks/epoch/{epoch_number}/slot/{slot_number}
 
     :param epoch_number: Epoch for specific epoch slot.
     :type epoch_number: int
@@ -122,7 +122,7 @@ def blocks_next(self, hash_or_number: str, **kwargs):
     """
     Return the list of blocks following a specific block.
 
-    https://docs.blockfrost.io/#tag/Cardano-Blocks/paths/~1blocks~1{hash_or_number}~1next/get
+    https://docs.blockfrost.io/#tag/cardano--blocks/GET/blocks/{hash_or_number}/next
 
     :param hash_or_number: Hash or number of the requested block.
     :type hash_or_number: str
@@ -151,7 +151,7 @@ def blocks_previous(self, hash_or_number: str, **kwargs):
     """
     Return the list of blocks preceding a specific block.
 
-    https://docs.blockfrost.io/#tag/Cardano-Blocks/paths/~1blocks~1{hash_or_number}~1previous/get
+    https://docs.blockfrost.io/#tag/cardano--blocks/GET/blocks/{hash_or_number}/previous
 
     :param hash_or_number: Hash or number of the requested block.
     :type hash_or_number: str
@@ -180,7 +180,7 @@ def block_transactions(self, hash_or_number: str, **kwargs):
     """
     Return the transactions within the block.
 
-    https://docs.blockfrost.io/#tag/Cardano-Blocks/paths/~1blocks~1{hash_or_number}~1txs/get
+    https://docs.blockfrost.io/#tag/cardano--blocks/GET/blocks/{hash_or_number}/txs
 
     :param hash_or_number: Hash or number of the requested block.
     :type hash_or_number: str
@@ -209,7 +209,7 @@ def block_latest_transactions_cbor(self, **kwargs):
     """
     Return the transactions within the latest block in CBOR format.
 
-    https://docs.blockfrost.io/#tag/Cardano-Blocks/paths/~1blocks~1latest~1txs~1cbor/get
+    https://docs.blockfrost.io/#tag/cardano--blocks/GET/blocks/latest/txs/cbor
 
     :param gather_pages: Optional. Default: false. Will collect all pages into one return
     :type gather_pages: bool
@@ -236,7 +236,7 @@ def block_transactions_cbor(self, hash_or_number: str, **kwargs):
     """
     Return the transactions within the block in CBOR format.
 
-    https://docs.blockfrost.io/#tag/Cardano-Blocks/paths/~1blocks~1{hash_or_number}~1txs~1cbor/get
+    https://docs.blockfrost.io/#tag/cardano--blocks/GET/blocks/{hash_or_number}/txs/cbor
 
     :param hash_or_number: Hash or number of the requested block.
     :type hash_or_number: str
@@ -265,7 +265,7 @@ def blocks_addresses(self, hash_or_number: str, **kwargs):
     """
     Return list of addresses affected in the specified block with additional information, sorted by the bech32 address, ascending.
 
-    https://docs.blockfrost.io/#tag/Cardano-Blocks/paths/~1blocks~1{hash_or_number}~1addresses/get
+    https://docs.blockfrost.io/#tag/cardano--blocks/GET/blocks/{hash_or_number}/addresses
 
     :param hash_or_number: Hash or number of the requested block.
     :type hash_or_number: str

--- a/blockfrost/api/cardano/epochs.py
+++ b/blockfrost/api/cardano/epochs.py
@@ -8,7 +8,7 @@ def epoch_latest(self, **kwargs):
     """
     Return the information about the latest, therefore current, epoch.
 
-    https://docs.blockfrost.io/#tag/Cardano-Epochs/paths/~1epochs~1latest/get
+    https://docs.blockfrost.io/#tag/cardano--epochs/GET/epochs/latest
 
     :param return_type: Optional. "object", "json" or "pandas". Default: "object".
     :type return_type: str
@@ -28,7 +28,7 @@ def epoch_latest_parameters(self, **kwargs):
     """
     Return the protocol parameters for the latest epoch.
 
-    https://docs.blockfrost.io/#tag/Cardano-Epochs/paths/~1epochs~1latest~1parameters/get
+    https://docs.blockfrost.io/#tag/cardano--epochs/GET/epochs/latest/parameters
 
     :param return_type: Optional. "object", "json" or "pandas". Default: "object".
     :type return_type: str
@@ -48,7 +48,7 @@ def epoch(self, number: int, **kwargs):
     """
     Return the content of the requested epoch.
 
-    https://docs.blockfrost.io/#tag/Cardano-Epochs/paths/~1epochs~1{number}/get
+    https://docs.blockfrost.io/#tag/cardano--epochs/GET/epochs/{number}
 
     :param number: Number of the epoch.
     :type number: int
@@ -70,7 +70,7 @@ def epochs_next(self, number: int, **kwargs):
     """
     Return the list of epochs following a specific epoch.
 
-    https://docs.blockfrost.io/#tag/Cardano-Epochs/paths/~1epochs~1{number}~1next/get
+    https://docs.blockfrost.io/#tag/cardano--epochs/GET/epochs/{number}/next
 
     :param number: Number of the epoch.
     :type number: int
@@ -99,7 +99,7 @@ def epochs_previous(self, number: int, **kwargs):
     """
     Return the list of epochs preceding a specific epoch.
 
-    https://docs.blockfrost.io/#tag/Cardano-Epochs/paths/~1epochs~1{number}~1previous/get
+    https://docs.blockfrost.io/#tag/cardano--epochs/GET/epochs/{number}/previous
 
     :param number: Number of the epoch.
     :type number: int
@@ -128,7 +128,7 @@ def epoch_stakes(self, number: int, **kwargs):
     """
     Return the active stake distribution for the specified epoch.
 
-    https://docs.blockfrost.io/#tag/Cardano-Epochs/paths/~1epochs~1{number}~1stakes/get
+    https://docs.blockfrost.io/#tag/cardano--epochs/GET/epochs/{number}/stakes
 
     :param number: Number of the epoch.
     :type number: int
@@ -157,7 +157,7 @@ def epoch_pool_stakes(self, number: int, pool_id: str, **kwargs):
     """
     Return the active stake distribution for the epoch specified by stake pool.
 
-    https://docs.blockfrost.io/#tag/Cardano-Epochs/paths/~1epochs~1{number}~1stakes~1{pool_id}/get
+    https://docs.blockfrost.io/#tag/cardano--epochs/GET/epochs/{number}/stakes/{pool_id}
 
     :param number: Number of the epoch.
     :type number: int
@@ -188,7 +188,7 @@ def epoch_blocks(self, number: int, **kwargs):
     """
     Return the blocks minted for the epoch specified.
 
-    https://docs.blockfrost.io/#tag/Cardano-Epochs/paths/~1epochs~1{number}~1blocks/get
+    https://docs.blockfrost.io/#tag/cardano--epochs/GET/epochs/{number}/blocks
 
     :param number: Number of the epoch.
     :type number: int
@@ -217,7 +217,7 @@ def epoch_pool_blocks(self, number: int, pool_id: str, **kwargs):
     """
     Return the block minted for the epoch specified by stake pool.
 
-    https://docs.blockfrost.io/#tag/Cardano-Epochs/paths/~1epochs~1{number}~1blocks~1{pool_id}/get
+    https://docs.blockfrost.io/#tag/cardano--epochs/GET/epochs/{number}/blocks/{pool_id}
 
     :param number: Number of the epoch.
     :type number: int
@@ -248,7 +248,7 @@ def epoch_protocol_parameters(self, number: int, **kwargs):
     """
     Return the protocol parameters for the epoch specified.
 
-    https://docs.blockfrost.io/#tag/Cardano-Epochs/paths/~1epochs~1{number}~1parameters/get
+    https://docs.blockfrost.io/#tag/cardano--epochs/GET/epochs/{number}/parameters
 
     :param number: Number of the epoch.
     :type number: int

--- a/blockfrost/api/cardano/governance.py
+++ b/blockfrost/api/cardano/governance.py
@@ -333,3 +333,131 @@ def governance_proposal_metadata(self, tx_hash: str, cert_index: int, **kwargs):
         url=f"{self.url}/governance/proposals/{tx_hash}/{cert_index}/metadata",
         headers=self.default_headers
     )
+
+
+@request_wrapper
+def governance_proposal_by_gov_action_id(self, gov_action_id: str, **kwargs):
+    """
+    Return information about a specific governance proposal by GovActionID.
+
+    https://docs.blockfrost.io/#tag/cardano--governance/GET/governance/proposals/{gov_action_id}
+
+    :param gov_action_id: Governance Action Identifier (CIP-0129).
+    :type gov_action_id: str
+    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
+    :type return_type: str
+    :returns object.
+    :rtype: Namespace
+    :raises ApiError: If API fails
+    :raises Exception: If the API response is somehow malformed.
+    """
+    return requests.get(
+        url=f"{self.url}/governance/proposals/{gov_action_id}",
+        headers=self.default_headers
+    )
+
+
+@request_wrapper
+def governance_proposal_parameters_by_gov_action_id(self, gov_action_id: str, **kwargs):
+    """
+    Return the parameters of a specific governance proposal by GovActionID.
+
+    https://docs.blockfrost.io/#tag/cardano--governance/GET/governance/proposals/{gov_action_id}/parameters
+
+    :param gov_action_id: Governance Action Identifier (CIP-0129).
+    :type gov_action_id: str
+    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
+    :type return_type: str
+    :returns object.
+    :rtype: Namespace
+    :raises ApiError: If API fails
+    :raises Exception: If the API response is somehow malformed.
+    """
+    return requests.get(
+        url=f"{self.url}/governance/proposals/{gov_action_id}/parameters",
+        headers=self.default_headers
+    )
+
+
+@list_request_wrapper
+def governance_proposal_withdrawals_by_gov_action_id(self, gov_action_id: str, **kwargs):
+    """
+    Return the withdrawals of a specific governance proposal by GovActionID.
+
+    https://docs.blockfrost.io/#tag/cardano--governance/GET/governance/proposals/{gov_action_id}/withdrawals
+
+    :param gov_action_id: Governance Action Identifier (CIP-0129).
+    :type gov_action_id: str
+    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
+    :type return_type: str
+    :param gather_pages: Optional. Default: false. Will collect all pages into one return
+    :type gather_pages: bool
+    :param count: Optional. Default: 100. The number of results displayed on one page.
+    :type count: int
+    :param page: Optional. The page number for listing the results.
+    :type page: int
+    :param order: Optional. "asc" or "desc". Default: "asc".
+    :type order: str
+    :returns A list of objects.
+    :rtype [Namespace]
+    :raises ApiError: If API fails
+    :raises Exception: If the API response is somehow malformed.
+    """
+    return requests.get(
+        url=f"{self.url}/governance/proposals/{gov_action_id}/withdrawals",
+        params=self.query_parameters(kwargs),
+        headers=self.default_headers
+    )
+
+
+@list_request_wrapper
+def governance_proposal_votes_by_gov_action_id(self, gov_action_id: str, **kwargs):
+    """
+    Return the votes of a specific governance proposal by GovActionID.
+
+    https://docs.blockfrost.io/#tag/cardano--governance/GET/governance/proposals/{gov_action_id}/votes
+
+    :param gov_action_id: Governance Action Identifier (CIP-0129).
+    :type gov_action_id: str
+    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
+    :type return_type: str
+    :param gather_pages: Optional. Default: false. Will collect all pages into one return
+    :type gather_pages: bool
+    :param count: Optional. Default: 100. The number of results displayed on one page.
+    :type count: int
+    :param page: Optional. The page number for listing the results.
+    :type page: int
+    :param order: Optional. "asc" or "desc". Default: "asc".
+    :type order: str
+    :returns A list of objects.
+    :rtype [Namespace]
+    :raises ApiError: If API fails
+    :raises Exception: If the API response is somehow malformed.
+    """
+    return requests.get(
+        url=f"{self.url}/governance/proposals/{gov_action_id}/votes",
+        params=self.query_parameters(kwargs),
+        headers=self.default_headers
+    )
+
+
+@request_wrapper
+def governance_proposal_metadata_by_gov_action_id(self, gov_action_id: str, **kwargs):
+    """
+    Return the metadata of a specific governance proposal by GovActionID.
+
+    https://docs.blockfrost.io/#tag/cardano--governance/GET/governance/proposals/{gov_action_id}/metadata
+
+    :param gov_action_id: Governance Action Identifier (CIP-0129).
+    :type gov_action_id: str
+    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
+    :type return_type: str
+    :returns object.
+    :rtype: Namespace
+    :raises ApiError: If API fails
+    :raises Exception: If the API response is somehow malformed.
+    """
+    return requests.get(
+        url=f"{self.url}/governance/proposals/{gov_action_id}/metadata",
+        headers=self.default_headers
+    )

--- a/blockfrost/api/cardano/governance.py
+++ b/blockfrost/api/cardano/governance.py
@@ -7,7 +7,7 @@ def governance_dreps(self, **kwargs):
     """
     Return the list of registered delegated representatives (DReps).
 
-    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1dreps/get
+    https://docs.blockfrost.io/#tag/cardano--governance/GET/governance/dreps
 
     :param return_type: Optional. "object", "json" or "pandas". Default: "object".
     :type return_type: str
@@ -36,7 +36,7 @@ def governance_drep(self, drep_id: str, **kwargs):
     """
     Return information about a specific delegated representative (DRep).
 
-    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1dreps~1{drep_id}/get
+    https://docs.blockfrost.io/#tag/cardano--governance/GET/governance/dreps/{drep_id}
 
     :param drep_id: The DRep ID (Bech32 or hex encoded).
     :type drep_id: str
@@ -58,7 +58,7 @@ def governance_drep_delegators(self, drep_id: str, **kwargs):
     """
     Return the list of delegators to a specific DRep.
 
-    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1dreps~1{drep_id}~1delegators/get
+    https://docs.blockfrost.io/#tag/cardano--governance/GET/governance/dreps/{drep_id}/delegators
 
     :param drep_id: The DRep ID (Bech32 or hex encoded).
     :type drep_id: str
@@ -89,7 +89,7 @@ def governance_drep_metadata(self, drep_id: str, **kwargs):
     """
     Return the metadata of a specific DRep.
 
-    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1dreps~1{drep_id}~1metadata/get
+    https://docs.blockfrost.io/#tag/cardano--governance/GET/governance/dreps/{drep_id}/metadata
 
     :param drep_id: The DRep ID (Bech32 or hex encoded).
     :type drep_id: str
@@ -111,7 +111,7 @@ def governance_drep_updates(self, drep_id: str, **kwargs):
     """
     Return the list of certificate updates to a specific DRep.
 
-    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1dreps~1{drep_id}~1updates/get
+    https://docs.blockfrost.io/#tag/cardano--governance/GET/governance/dreps/{drep_id}/updates
 
     :param drep_id: The DRep ID (Bech32 or hex encoded).
     :type drep_id: str
@@ -142,7 +142,7 @@ def governance_drep_votes(self, drep_id: str, **kwargs):
     """
     Return the list of votes by a specific DRep.
 
-    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1dreps~1{drep_id}~1votes/get
+    https://docs.blockfrost.io/#tag/cardano--governance/GET/governance/dreps/{drep_id}/votes
 
     :param drep_id: The DRep ID (Bech32 or hex encoded).
     :type drep_id: str
@@ -173,7 +173,7 @@ def governance_proposals(self, **kwargs):
     """
     Return the list of governance proposals.
 
-    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1proposals/get
+    https://docs.blockfrost.io/#tag/cardano--governance/GET/governance/proposals
 
     :param return_type: Optional. "object", "json" or "pandas". Default: "object".
     :type return_type: str
@@ -202,7 +202,7 @@ def governance_proposal(self, tx_hash: str, cert_index: int, **kwargs):
     """
     Return information about a specific governance proposal.
 
-    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1proposals~1{tx_hash}~1{cert_index}/get
+    https://docs.blockfrost.io/#tag/cardano--governance/GET/governance/proposals/{tx_hash}/{cert_index}
 
     :param tx_hash: The transaction hash of the proposal.
     :type tx_hash: str
@@ -226,7 +226,7 @@ def governance_proposal_parameters(self, tx_hash: str, cert_index: int, **kwargs
     """
     Return the parameters of a specific governance proposal.
 
-    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1proposals~1{tx_hash}~1{cert_index}~1parameters/get
+    https://docs.blockfrost.io/#tag/cardano--governance/GET/governance/proposals/{tx_hash}/{cert_index}/parameters
 
     :param tx_hash: The transaction hash of the proposal.
     :type tx_hash: str
@@ -250,7 +250,7 @@ def governance_proposal_withdrawals(self, tx_hash: str, cert_index: int, **kwarg
     """
     Return the withdrawals of a specific governance proposal.
 
-    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1proposals~1{tx_hash}~1{cert_index}~1withdrawals/get
+    https://docs.blockfrost.io/#tag/cardano--governance/GET/governance/proposals/{tx_hash}/{cert_index}/withdrawals
 
     :param tx_hash: The transaction hash of the proposal.
     :type tx_hash: str
@@ -283,7 +283,7 @@ def governance_proposal_votes(self, tx_hash: str, cert_index: int, **kwargs):
     """
     Return the votes of a specific governance proposal.
 
-    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1proposals~1{tx_hash}~1{cert_index}~1votes/get
+    https://docs.blockfrost.io/#tag/cardano--governance/GET/governance/proposals/{tx_hash}/{cert_index}/votes
 
     :param tx_hash: The transaction hash of the proposal.
     :type tx_hash: str
@@ -316,7 +316,7 @@ def governance_proposal_metadata(self, tx_hash: str, cert_index: int, **kwargs):
     """
     Return the metadata of a specific governance proposal.
 
-    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1proposals~1{tx_hash}~1{cert_index}~1metadata/get
+    https://docs.blockfrost.io/#tag/cardano--governance/GET/governance/proposals/{tx_hash}/{cert_index}/metadata
 
     :param tx_hash: The transaction hash of the proposal.
     :type tx_hash: str

--- a/blockfrost/api/cardano/governance.py
+++ b/blockfrost/api/cardano/governance.py
@@ -2,15 +2,44 @@ import requests
 from blockfrost.utils import request_wrapper, list_request_wrapper
 
 
-@request_wrapper
-def accounts(self, stake_address: str, **kwargs):
+@list_request_wrapper
+def governance_dreps(self, **kwargs):
     """
-    Obtain information about a specific networkStake account.
+    Return the list of registered delegated representatives (DReps).
 
-    https://docs.blockfrost.io/#tag/Cardano-Accounts/paths/~1accounts~1{stake_address}/get
+    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1dreps/get
 
-    :param stake_address: Bech32 stake address.
-    :type stake_address: str
+    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
+    :type return_type: str
+    :param gather_pages: Optional. Default: false. Will collect all pages into one return
+    :type gather_pages: bool
+    :param count: Optional. Default: 100. The number of results displayed on one page.
+    :type count: int
+    :param page: Optional. The page number for listing the results.
+    :type page: int
+    :param order: Optional. "asc" or "desc". Default: "asc".
+    :type order: str
+    :returns A list of objects.
+    :rtype [Namespace]
+    :raises ApiError: If API fails
+    :raises Exception: If the API response is somehow malformed.
+    """
+    return requests.get(
+        url=f"{self.url}/governance/dreps",
+        params=self.query_parameters(kwargs),
+        headers=self.default_headers
+    )
+
+
+@request_wrapper
+def governance_drep(self, drep_id: str, **kwargs):
+    """
+    Return information about a specific delegated representative (DRep).
+
+    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1dreps~1{drep_id}/get
+
+    :param drep_id: The DRep ID (Bech32 or hex encoded).
+    :type drep_id: str
     :param return_type: Optional. "object", "json" or "pandas". Default: "object".
     :type return_type: str
     :returns object.
@@ -19,20 +48,20 @@ def accounts(self, stake_address: str, **kwargs):
     :raises Exception: If the API response is somehow malformed.
     """
     return requests.get(
-        url=f"{self.url}/accounts/{stake_address}",
+        url=f"{self.url}/governance/dreps/{drep_id}",
         headers=self.default_headers
     )
 
 
 @list_request_wrapper
-def account_rewards(self, stake_address: str, **kwargs):
+def governance_drep_delegators(self, drep_id: str, **kwargs):
     """
-    Obtain information about the history of a specific account.
+    Return the list of delegators to a specific DRep.
 
-    https://docs.blockfrost.io/#tag/Cardano-Accounts/paths/~1accounts~1{stake_address}~1rewards/get
+    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1dreps~1{drep_id}~1delegators/get
 
-    :param stake_address: Bech32 stake address.
-    :type stake_address: str
+    :param drep_id: The DRep ID (Bech32 or hex encoded).
+    :type drep_id: str
     :param return_type: Optional. "object", "json" or "pandas". Default: "object".
     :type return_type: str
     :param gather_pages: Optional. Default: false. Will collect all pages into one return
@@ -49,304 +78,21 @@ def account_rewards(self, stake_address: str, **kwargs):
     :raises Exception: If the API response is somehow malformed.
     """
     return requests.get(
-        url=f"{self.url}/accounts/{stake_address}/rewards",
-        params=self.query_parameters(kwargs),
-        headers=self.default_headers
-    )
-
-
-@list_request_wrapper
-def account_history(self, stake_address: str, **kwargs):
-    """
-    Obtain information about the history of a specific account.
-
-    https://docs.blockfrost.io/#tag/Cardano-Accounts/paths/~1accounts~1{stake_address}~1history/get
-
-    :param stake_address: Bech32 stake address.
-    :type stake_address: str
-    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
-    :type return_type: str
-    :param gather_pages: Optional. Default: false. Will collect all pages into one return
-    :type gather_pages: bool
-    :param count: Optional. Default: 100. The number of results displayed on one page.
-    :type count: int
-    :param page: Optional. The page number for listing the results.
-    :type page: int
-    :param order: Optional. "asc" or "desc". Default: "asc".
-    :type order: str
-    :returns A list of objects.
-    :rtype [Namespace]
-    :raises ApiError: If API fails
-    :raises Exception: If the API response is somehow malformed.
-    """
-    return requests.get(
-        url=f"{self.url}/accounts/{stake_address}/history",
-        params=self.query_parameters(kwargs),
-        headers=self.default_headers
-    )
-
-
-@list_request_wrapper
-def account_delegations(self, stake_address: str, **kwargs):
-    """
-    Obtain information about the delegation of a specific account.
-
-    https://docs.blockfrost.io/#tag/Cardano-Accounts/paths/~1accounts~1{stake_address}~1delegations/get
-
-    :param stake_address: Bech32 stake address.
-    :type stake_address: str
-    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
-    :type return_type: str
-    :param gather_pages: Optional. Default: false. Will collect all pages into one return
-    :type gather_pages: bool
-    :param count: Optional. Default: 100. The number of results displayed on one page.
-    :type count: int
-    :param page: Optional. The page number for listing the results.
-    :type page: int
-    :param order: Optional. "asc" or "desc". Default: "asc".
-    :type order: str
-    :returns A list of objects.
-    :rtype [Namespace]
-    :raises ApiError: If API fails
-    :raises Exception: If the API response is somehow malformed.
-    """
-    return requests.get(
-        url=f"{self.url}/accounts/{stake_address}/delegations",
-        params=self.query_parameters(kwargs),
-        headers=self.default_headers
-    )
-
-
-@list_request_wrapper
-def account_registrations(self, stake_address: str, **kwargs):
-    """
-    Obtain information about the registrations and deregistrations of a specific account.
-
-    https://docs.blockfrost.io/#tag/Cardano-Accounts/paths/~1accounts~1{stake_address}~1registrations/get
-
-    :param stake_address: Bech32 stake address.
-    :type stake_address: str
-    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
-    :type return_type: str
-    :param gather_pages: Optional. Default: false. Will collect all pages into one return
-    :type gather_pages: bool
-    :param count: Optional. Default: 100. The number of results displayed on one page.
-    :type count: int
-    :param page: Optional. The page number for listing the results.
-    :type page: int
-    :param order: Optional. "asc" or "desc". Default: "asc".
-    :type order: str
-    :returns A list of objects.
-    :rtype [Namespace]
-    :raises ApiError: If API fails
-    :raises Exception: If the API response is somehow malformed.
-    """
-    return requests.get(
-        url=f"{self.url}/accounts/{stake_address}/registrations",
-        params=self.query_parameters(kwargs),
-        headers=self.default_headers
-    )
-
-
-@list_request_wrapper
-def account_withdrawals(self, stake_address: str, **kwargs):
-    """
-    Obtain information about the withdrawals of a specific account.
-
-    https://docs.blockfrost.io/#tag/Cardano-Accounts/paths/~1accounts~1{stake_address}~1withdrawals/get
-
-    :param stake_address: Bech32 stake address.
-    :type stake_address: str
-    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
-    :type return_type: str
-    :param gather_pages: Optional. Default: false. Will collect all pages into one return
-    :type gather_pages: bool
-    :param count: Optional. Default: 100. The number of results displayed on one page.
-    :type count: int
-    :param page: Optional. The page number for listing the results.
-    :type page: int
-    :param order: Optional. "asc" or "desc". Default: "asc".
-    :type order: str
-    :returns A list of objects.
-    :rtype [Namespace]
-    :raises ApiError: If API fails
-    :raises Exception: If the API response is somehow malformed.
-    """
-    return requests.get(
-        url=f"{self.url}/accounts/{stake_address}/withdrawals",
-        params=self.query_parameters(kwargs),
-        headers=self.default_headers
-    )
-
-
-@list_request_wrapper
-def account_mirs(self, stake_address: str, **kwargs):
-    """
-    Obtain information about the MIRs of a specific account.
-
-    https://docs.blockfrost.io/#tag/Cardano-Accounts/paths/~1accounts~1{stake_address}~1mirs/get
-
-    :param stake_address: Bech32 stake address.
-    :type stake_address: str
-    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
-    :type return_type: str
-    :param gather_pages: Optional. Default: false. Will collect all pages into one return
-    :type gather_pages: bool
-    :param count: Optional. Default: 100. The number of results displayed on one page.
-    :type count: int
-    :param page: Optional. The page number for listing the results.
-    :type page: int
-    :param order: Optional. "asc" or "desc". Default: "asc".
-    :type order: str
-    :returns A list of objects.
-    :rtype [Namespace]
-    :raises ApiError: If API fails
-    :raises Exception: If the API response is somehow malformed.
-    """
-    return requests.get(
-        url=f"{self.url}/accounts/{stake_address}/mirs",
-        params=self.query_parameters(kwargs),
-        headers=self.default_headers
-    )
-
-
-@list_request_wrapper
-def account_addresses(self, stake_address: str, **kwargs):
-    """
-    Obtain information about the addresses of a specific account.
-
-    https://docs.blockfrost.io/#tag/Cardano-Accounts/paths/~1accounts~1{stake_address}~1addresses/get
-
-    :param stake_address: Bech32 stake address.
-    :type stake_address: str
-    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
-    :type return_type: str
-    :param gather_pages: Optional. Default: false. Will collect all pages into one return
-    :type gather_pages: bool
-    :param count: Optional. Default: 100. The number of results displayed on one page.
-    :type count: int
-    :param page: Optional. The page number for listing the results.
-    :type page: int
-    :param order: Optional. "asc" or "desc". Default: "asc".
-    :type order: str
-    :returns A list of objects.
-    :rtype [Namespace]
-    :raises ApiError: If API fails
-    :raises Exception: If the API response is somehow malformed.
-    """
-    return requests.get(
-        url=f"{self.url}/accounts/{stake_address}/addresses",
-        params=self.query_parameters(kwargs),
-        headers=self.default_headers
-    )
-
-
-@list_request_wrapper
-def account_addresses_assets(self, stake_address: str, **kwargs):
-    """
-    Obtain information about assets associated with addresses of a specific account.
-
-    Be careful, as an account could be part of a mangled address and does not necessarily mean the addresses are owned by user as the account.
-
-    https://docs.blockfrost.io/#tag/Cardano-Accounts/paths/~1accounts~1{stake_address}~1addresses~1assets/get
-
-    :param stake_address: Bech32 stake address.
-    :type stake_address: str
-    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
-    :type return_type: str
-    :param gather_pages: Optional. Default: false. Will collect all pages into one return
-    :type gather_pages: bool
-    :param count: Optional. Default: 100. The number of results displayed on one page.
-    :type count: int
-    :param page: Optional. The page number for listing the results.
-    :type page: int
-    :param order: Optional. "asc" or "desc". Default: "asc".
-    :type order: str
-    :returns A list of objects.
-    :rtype [Namespace]
-    :raises ApiError: If API fails
-    :raises Exception: If the API response is somehow malformed.
-    """
-    return requests.get(
-        url=f"{self.url}/accounts/{stake_address}/addresses/assets",
-        params=self.query_parameters(kwargs),
-        headers=self.default_headers
-    )
-
-
-@list_request_wrapper
-def account_utxos(self, stake_address: str, **kwargs):
-    """
-    Obtain information about UTXOs of a specific account.
-
-    https://docs.blockfrost.io/#tag/Cardano-Accounts/paths/~1accounts~1{stake_address}~1utxos/get
-
-    :param stake_address: Bech32 stake address.
-    :type stake_address: str
-    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
-    :type return_type: str
-    :param gather_pages: Optional. Default: false. Will collect all pages into one return
-    :type gather_pages: bool
-    :param count: Optional. Default: 100. The number of results displayed on one page.
-    :type count: int
-    :param page: Optional. The page number for listing the results.
-    :type page: int
-    :param order: Optional. "asc" or "desc". Default: "asc".
-    :type order: str
-    :returns A list of objects.
-    :rtype [Namespace]
-    :raises ApiError: If API fails
-    :raises Exception: If the API response is somehow malformed.
-    """
-    return requests.get(
-        url=f"{self.url}/accounts/{stake_address}/utxos",
-        params=self.query_parameters(kwargs),
-        headers=self.default_headers
-    )
-
-
-@list_request_wrapper
-def account_transactions(self, stake_address: str, **kwargs):
-    """
-    Obtain information about transactions associated with a specific account.
-
-    https://docs.blockfrost.io/#tag/Cardano-Accounts/paths/~1accounts~1{stake_address}~1transactions/get
-
-    :param stake_address: Bech32 stake address.
-    :type stake_address: str
-    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
-    :type return_type: str
-    :param gather_pages: Optional. Default: false. Will collect all pages into one return
-    :type gather_pages: bool
-    :param count: Optional. Default: 100. The number of results displayed on one page.
-    :type count: int
-    :param page: Optional. The page number for listing the results.
-    :type page: int
-    :param order: Optional. "asc" or "desc". Default: "asc".
-    :type order: str
-    :returns A list of objects.
-    :rtype [Namespace]
-    :raises ApiError: If API fails
-    :raises Exception: If the API response is somehow malformed.
-    """
-    return requests.get(
-        url=f"{self.url}/accounts/{stake_address}/transactions",
+        url=f"{self.url}/governance/dreps/{drep_id}/delegators",
         params=self.query_parameters(kwargs),
         headers=self.default_headers
     )
 
 
 @request_wrapper
-def account_addresses_total(self, stake_address: str, **kwargs):
+def governance_drep_metadata(self, drep_id: str, **kwargs):
     """
-    Obtain summed details about all addresses associated with a given account.
+    Return the metadata of a specific DRep.
 
-    Be careful, as an account could be part of a mangled address and does not necessarily mean the addresses are owned by user as the account.
+    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1dreps~1{drep_id}~1metadata/get
 
-    https://docs.blockfrost.io/#tag/Cardano-Addresses/paths/~1accounts~1{stake_address}~1addresses~1total/get
-
-    :param stake_address: Bech32 address.
-    :type stake_address: str
+    :param drep_id: The DRep ID (Bech32 or hex encoded).
+    :type drep_id: str
     :param return_type: Optional. "object", "json" or "pandas". Default: "object".
     :type return_type: str
     :returns object.
@@ -355,6 +101,235 @@ def account_addresses_total(self, stake_address: str, **kwargs):
     :raises Exception: If the API response is somehow malformed.
     """
     return requests.get(
-        url=f"{self.url}/accounts/{stake_address}/addresses/total",
+        url=f"{self.url}/governance/dreps/{drep_id}/metadata",
+        headers=self.default_headers
+    )
+
+
+@list_request_wrapper
+def governance_drep_updates(self, drep_id: str, **kwargs):
+    """
+    Return the list of certificate updates to a specific DRep.
+
+    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1dreps~1{drep_id}~1updates/get
+
+    :param drep_id: The DRep ID (Bech32 or hex encoded).
+    :type drep_id: str
+    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
+    :type return_type: str
+    :param gather_pages: Optional. Default: false. Will collect all pages into one return
+    :type gather_pages: bool
+    :param count: Optional. Default: 100. The number of results displayed on one page.
+    :type count: int
+    :param page: Optional. The page number for listing the results.
+    :type page: int
+    :param order: Optional. "asc" or "desc". Default: "asc".
+    :type order: str
+    :returns A list of objects.
+    :rtype [Namespace]
+    :raises ApiError: If API fails
+    :raises Exception: If the API response is somehow malformed.
+    """
+    return requests.get(
+        url=f"{self.url}/governance/dreps/{drep_id}/updates",
+        params=self.query_parameters(kwargs),
+        headers=self.default_headers
+    )
+
+
+@list_request_wrapper
+def governance_drep_votes(self, drep_id: str, **kwargs):
+    """
+    Return the list of votes by a specific DRep.
+
+    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1dreps~1{drep_id}~1votes/get
+
+    :param drep_id: The DRep ID (Bech32 or hex encoded).
+    :type drep_id: str
+    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
+    :type return_type: str
+    :param gather_pages: Optional. Default: false. Will collect all pages into one return
+    :type gather_pages: bool
+    :param count: Optional. Default: 100. The number of results displayed on one page.
+    :type count: int
+    :param page: Optional. The page number for listing the results.
+    :type page: int
+    :param order: Optional. "asc" or "desc". Default: "asc".
+    :type order: str
+    :returns A list of objects.
+    :rtype [Namespace]
+    :raises ApiError: If API fails
+    :raises Exception: If the API response is somehow malformed.
+    """
+    return requests.get(
+        url=f"{self.url}/governance/dreps/{drep_id}/votes",
+        params=self.query_parameters(kwargs),
+        headers=self.default_headers
+    )
+
+
+@list_request_wrapper
+def governance_proposals(self, **kwargs):
+    """
+    Return the list of governance proposals.
+
+    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1proposals/get
+
+    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
+    :type return_type: str
+    :param gather_pages: Optional. Default: false. Will collect all pages into one return
+    :type gather_pages: bool
+    :param count: Optional. Default: 100. The number of results displayed on one page.
+    :type count: int
+    :param page: Optional. The page number for listing the results.
+    :type page: int
+    :param order: Optional. "asc" or "desc". Default: "asc".
+    :type order: str
+    :returns A list of objects.
+    :rtype [Namespace]
+    :raises ApiError: If API fails
+    :raises Exception: If the API response is somehow malformed.
+    """
+    return requests.get(
+        url=f"{self.url}/governance/proposals",
+        params=self.query_parameters(kwargs),
+        headers=self.default_headers
+    )
+
+
+@request_wrapper
+def governance_proposal(self, tx_hash: str, cert_index: int, **kwargs):
+    """
+    Return information about a specific governance proposal.
+
+    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1proposals~1{tx_hash}~1{cert_index}/get
+
+    :param tx_hash: The transaction hash of the proposal.
+    :type tx_hash: str
+    :param cert_index: The index of the certificate within the proposal transaction.
+    :type cert_index: int
+    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
+    :type return_type: str
+    :returns object.
+    :rtype: Namespace
+    :raises ApiError: If API fails
+    :raises Exception: If the API response is somehow malformed.
+    """
+    return requests.get(
+        url=f"{self.url}/governance/proposals/{tx_hash}/{cert_index}",
+        headers=self.default_headers
+    )
+
+
+@request_wrapper
+def governance_proposal_parameters(self, tx_hash: str, cert_index: int, **kwargs):
+    """
+    Return the parameters of a specific governance proposal.
+
+    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1proposals~1{tx_hash}~1{cert_index}~1parameters/get
+
+    :param tx_hash: The transaction hash of the proposal.
+    :type tx_hash: str
+    :param cert_index: The index of the certificate within the proposal transaction.
+    :type cert_index: int
+    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
+    :type return_type: str
+    :returns object.
+    :rtype: Namespace
+    :raises ApiError: If API fails
+    :raises Exception: If the API response is somehow malformed.
+    """
+    return requests.get(
+        url=f"{self.url}/governance/proposals/{tx_hash}/{cert_index}/parameters",
+        headers=self.default_headers
+    )
+
+
+@list_request_wrapper
+def governance_proposal_withdrawals(self, tx_hash: str, cert_index: int, **kwargs):
+    """
+    Return the withdrawals of a specific governance proposal.
+
+    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1proposals~1{tx_hash}~1{cert_index}~1withdrawals/get
+
+    :param tx_hash: The transaction hash of the proposal.
+    :type tx_hash: str
+    :param cert_index: The index of the certificate within the proposal transaction.
+    :type cert_index: int
+    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
+    :type return_type: str
+    :param gather_pages: Optional. Default: false. Will collect all pages into one return
+    :type gather_pages: bool
+    :param count: Optional. Default: 100. The number of results displayed on one page.
+    :type count: int
+    :param page: Optional. The page number for listing the results.
+    :type page: int
+    :param order: Optional. "asc" or "desc". Default: "asc".
+    :type order: str
+    :returns A list of objects.
+    :rtype [Namespace]
+    :raises ApiError: If API fails
+    :raises Exception: If the API response is somehow malformed.
+    """
+    return requests.get(
+        url=f"{self.url}/governance/proposals/{tx_hash}/{cert_index}/withdrawals",
+        params=self.query_parameters(kwargs),
+        headers=self.default_headers
+    )
+
+
+@list_request_wrapper
+def governance_proposal_votes(self, tx_hash: str, cert_index: int, **kwargs):
+    """
+    Return the votes of a specific governance proposal.
+
+    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1proposals~1{tx_hash}~1{cert_index}~1votes/get
+
+    :param tx_hash: The transaction hash of the proposal.
+    :type tx_hash: str
+    :param cert_index: The index of the certificate within the proposal transaction.
+    :type cert_index: int
+    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
+    :type return_type: str
+    :param gather_pages: Optional. Default: false. Will collect all pages into one return
+    :type gather_pages: bool
+    :param count: Optional. Default: 100. The number of results displayed on one page.
+    :type count: int
+    :param page: Optional. The page number for listing the results.
+    :type page: int
+    :param order: Optional. "asc" or "desc". Default: "asc".
+    :type order: str
+    :returns A list of objects.
+    :rtype [Namespace]
+    :raises ApiError: If API fails
+    :raises Exception: If the API response is somehow malformed.
+    """
+    return requests.get(
+        url=f"{self.url}/governance/proposals/{tx_hash}/{cert_index}/votes",
+        params=self.query_parameters(kwargs),
+        headers=self.default_headers
+    )
+
+
+@request_wrapper
+def governance_proposal_metadata(self, tx_hash: str, cert_index: int, **kwargs):
+    """
+    Return the metadata of a specific governance proposal.
+
+    https://docs.blockfrost.io/#tag/Cardano-Governance/paths/~1governance~1proposals~1{tx_hash}~1{cert_index}~1metadata/get
+
+    :param tx_hash: The transaction hash of the proposal.
+    :type tx_hash: str
+    :param cert_index: The index of the certificate within the proposal transaction.
+    :type cert_index: int
+    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
+    :type return_type: str
+    :returns object.
+    :rtype: Namespace
+    :raises ApiError: If API fails
+    :raises Exception: If the API response is somehow malformed.
+    """
+    return requests.get(
+        url=f"{self.url}/governance/proposals/{tx_hash}/{cert_index}/metadata",
         headers=self.default_headers
     )

--- a/blockfrost/api/cardano/ledger.py
+++ b/blockfrost/api/cardano/ledger.py
@@ -7,7 +7,7 @@ def genesis(self, **kwargs):
     """
     Return the information about blockchain genesis.
 
-    https://docs.blockfrost.io/#tag/Cardano-Ledger/paths/~1genesis/get
+    https://docs.blockfrost.io/#tag/cardano--ledger/GET/genesis
 
     :param return_type: Optional. "object", "json" or "pandas". Default: "object".
     :type return_type: str

--- a/blockfrost/api/cardano/mempool.py
+++ b/blockfrost/api/cardano/mempool.py
@@ -8,7 +8,7 @@ def mempool(self, **kwargs):
     Obtains transactions that are currently stored in Blockfrost mempool, waiting to be included in a newly minted block.
     Returns only transactions submitted via Blockfrost.io.
 
-    https://docs.blockfrost.io/#tag/Cardano-Mempool/paths/~1mempool/get
+    https://docs.blockfrost.io/#tag/cardano--mempool/GET/mempool
 
     :param return_type: Optional. "object", "json" or "pandas". Default: "object".
     :type return_type: str
@@ -34,7 +34,7 @@ def mempool_tx(self, hash: str, **kwargs):
     """
     Obtains mempool transaction
 
-    https://docs.blockfrost.io/#tag/Cardano-Mempool/paths/~1mempool~1%7Bhash%7D/get
+    https://docs.blockfrost.io/#tag/cardano--mempool/GET/mempool/{hash}
 
     :param hash: Hash of the requested transaction.
     :type hash: str
@@ -63,7 +63,7 @@ def mempool_address(self, address: str, **kwargs):
     Obtains list of mempool transactions where at least one of the transaction inputs or outputs belongs to the address (paginated).
     Shows only transactions submitted via Blockfrost.io.
 
-    https://docs.blockfrost.io/#tag/Cardano-Mempool/paths/~1mempool~1addresses~1%7Baddress%7D/get
+    https://docs.blockfrost.io/#tag/cardano--mempool/GET/mempool/addresses/{address}
 
     :param address: Bech32 address.
     :type address: str

--- a/blockfrost/api/cardano/metadata.py
+++ b/blockfrost/api/cardano/metadata.py
@@ -7,7 +7,7 @@ def metadata_labels(self, **kwargs):
     """
     List of all used transaction metadata labels.
 
-    https://docs.blockfrost.io/#tag/Cardano-Metadata/paths/~1metadata~1txs~1labels/get
+    https://docs.blockfrost.io/#tag/cardano--metadata/GET/metadata/txs/labels
 
     :param return_type: Optional. "object", "json" or "pandas". Default: "object".
     :type return_type: str
@@ -36,7 +36,7 @@ def metadata_label_json(self, label: str, **kwargs):
     """
     Transaction metadata per label.
 
-    https://docs.blockfrost.io/#tag/Cardano-Metadata/paths/~1metadata~1txs~1labels~1{label}/get
+    https://docs.blockfrost.io/#tag/cardano--metadata/GET/metadata/txs/labels/{label}
 
     :param label: Metadata label
     :type label: str
@@ -67,7 +67,7 @@ def metadata_label_cbor(self, label: str, **kwargs):
     """
     Transaction metadata per label.
 
-    https://docs.blockfrost.io/#tag/Cardano-Metadata/paths/~1metadata~1txs~1labels~1{label}~1cbor/get
+    https://docs.blockfrost.io/#tag/cardano--metadata/GET/metadata/txs/labels/{label}/cbor
 
     :param label: Metadata label
     :type label: str

--- a/blockfrost/api/cardano/network.py
+++ b/blockfrost/api/cardano/network.py
@@ -1,5 +1,5 @@
 import requests
-from blockfrost.utils import request_wrapper
+from blockfrost.utils import request_wrapper, list_request_wrapper
 
 
 @request_wrapper
@@ -18,5 +18,25 @@ def network(self, **kwargs):
     """
     return requests.get(
         url=f"{self.url}/network",
+        headers=self.default_headers
+    )
+
+
+@list_request_wrapper
+def network_eras(self, **kwargs):
+    """
+    Return the information about network eras.
+
+    https://docs.blockfrost.io/#tag/Cardano-Network/paths/~1network~1eras/get
+
+    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
+    :type return_type: str
+    :returns A list of objects.
+    :rtype [Namespace]
+    :raises ApiError: If API fails
+    :raises Exception: If the API response is somehow malformed.
+    """
+    return requests.get(
+        url=f"{self.url}/network/eras",
         headers=self.default_headers
     )

--- a/blockfrost/api/cardano/network.py
+++ b/blockfrost/api/cardano/network.py
@@ -1,5 +1,5 @@
 import requests
-from blockfrost.utils import request_wrapper, list_request_wrapper
+from blockfrost.utils import request_wrapper
 
 
 @request_wrapper
@@ -22,7 +22,7 @@ def network(self, **kwargs):
     )
 
 
-@list_request_wrapper
+@request_wrapper
 def network_eras(self, **kwargs):
     """
     Return the information about network eras.

--- a/blockfrost/api/cardano/network.py
+++ b/blockfrost/api/cardano/network.py
@@ -7,7 +7,7 @@ def network(self, **kwargs):
     """
     Return detailed network information.
 
-    https://docs.blockfrost.io/#tag/Cardano-Network/paths/~1network/get
+    https://docs.blockfrost.io/#tag/cardano--network/GET/network
 
     :param return_type: Optional. "object", "json" or "pandas". Default: "object".
     :type return_type: str
@@ -27,7 +27,7 @@ def network_eras(self, **kwargs):
     """
     Return the information about network eras.
 
-    https://docs.blockfrost.io/#tag/Cardano-Network/paths/~1network~1eras/get
+    https://docs.blockfrost.io/#tag/cardano--network/GET/network/eras
 
     :param return_type: Optional. "object", "json" or "pandas". Default: "object".
     :type return_type: str

--- a/blockfrost/api/cardano/pools.py
+++ b/blockfrost/api/cardano/pools.py
@@ -7,7 +7,7 @@ def pools(self, **kwargs):
     """
     List of registered stake pools.
 
-    https://docs.blockfrost.io/#tag/Cardano-Pools/paths/~1pools/get
+    https://docs.blockfrost.io/#tag/cardano--pools/GET/pools
 
     :param gather_pages: Optional. Default: false. Will collect all pages into one return
     :type gather_pages: bool
@@ -34,7 +34,7 @@ def pools_extended(self, **kwargs):
     """
     List of registered stake pools with additional information.
 
-    https://docs.blockfrost.io/#tag/Cardano-Pools/paths/~1pools~1extended/get
+    https://docs.blockfrost.io/#tag/cardano--pools/GET/pools/extended
 
     :param gather_pages: Optional. Default: false. Will collect all pages into one return
     :type gather_pages: bool
@@ -61,7 +61,7 @@ def pools_retired(self, **kwargs):
     """
     List of already retired pools.
 
-    https://docs.blockfrost.io/#tag/Cardano-Pools/paths/~1pools~1retired/get
+    https://docs.blockfrost.io/#tag/cardano--pools/GET/pools/retired
 
     :param gather_pages: Optional. Default: false. Will collect all pages into one return
     :type gather_pages: bool
@@ -88,7 +88,7 @@ def pools_retiring(self, **kwargs):
     """
     List of stake pools retiring in the upcoming epochs
 
-    https://docs.blockfrost.io/#tag/Cardano-Pools/paths/~1pools~1retiring/get
+    https://docs.blockfrost.io/#tag/cardano--pools/GET/pools/retiring
 
     :param gather_pages: Optional. Default: false. Will collect all pages into one return
     :type gather_pages: bool
@@ -115,7 +115,7 @@ def pool(self, pool_id: str, **kwargs):
     """
     Pool information.
 
-    https://docs.blockfrost.io/#tag/Cardano-Pools/paths/~1pools~1{pool_id}/get
+    https://docs.blockfrost.io/#tag/cardano--pools/GET/pools/{pool_id}
 
     :param pool_id: Bech32 or hexadecimal pool ID.
     :type pool_id: str
@@ -135,7 +135,7 @@ def pool_history(self, pool_id: str, **kwargs):
     """
     History of stake pool parameters over epochs.
 
-    https://docs.blockfrost.io/#tag/Cardano-Pools/paths/~1pools~1{pool_id}~1history/get
+    https://docs.blockfrost.io/#tag/cardano--pools/GET/pools/{pool_id}/history
 
     :param pool_id: Bech32 or hexadecimal pool ID.
     :type pool_id: str
@@ -164,7 +164,7 @@ def pool_metadata(self, pool_id: str, **kwargs):
     """
     Stake pool registration metadata.
 
-    https://docs.blockfrost.io/#tag/Cardano-Pools/paths/~1pools~1{pool_id}~1metadata/get
+    https://docs.blockfrost.io/#tag/cardano--pools/GET/pools/{pool_id}/metadata
 
     :param pool_id: Bech32 or hexadecimal pool ID.
     :type pool_id: str
@@ -184,7 +184,7 @@ def pool_relays(self, pool_id: str, **kwargs):
     """
     Relays of a stake pool.
 
-    https://docs.blockfrost.io/#tag/Cardano-Pools/paths/~1pools~1{pool_id}~1relays/get
+    https://docs.blockfrost.io/#tag/cardano--pools/GET/pools/{pool_id}/relays
 
     :param pool_id: Bech32 or hexadecimal pool ID.
     :type pool_id: str
@@ -204,7 +204,7 @@ def pool_delegators(self, pool_id: str, **kwargs):
     """
     List of current stake pools delegators.
 
-    https://docs.blockfrost.io/#tag/Cardano-Pools/paths/~1pools~1{pool_id}~1delegators/get
+    https://docs.blockfrost.io/#tag/cardano--pools/GET/pools/{pool_id}/delegators
 
     :param pool_id: Bech32 or hexadecimal pool ID.
     :type pool_id: str
@@ -233,7 +233,7 @@ def pool_blocks(self, pool_id: str, **kwargs):
     """
     List of stake pools blocks.
 
-    https://docs.blockfrost.io/#tag/Cardano-Pools/paths/~1pools~1{pool_id}~1blocks/get
+    https://docs.blockfrost.io/#tag/cardano--pools/GET/pools/{pool_id}/blocks
 
     :param pool_id: Bech32 or hexadecimal pool ID.
     :type pool_id: str
@@ -262,7 +262,7 @@ def pool_updates(self, pool_id: str, **kwargs):
     """
     List of certificate updates to the stake pool.
 
-    https://docs.blockfrost.io/#tag/Cardano-Pools/paths/~1pools~1{pool_id}~1updates/get
+    https://docs.blockfrost.io/#tag/cardano--pools/GET/pools/{pool_id}/updates
 
     :param pool_id: Bech32 or hexadecimal pool ID.
     :type pool_id: str

--- a/blockfrost/api/cardano/pools.py
+++ b/blockfrost/api/cardano/pools.py
@@ -179,7 +179,7 @@ def pool_metadata(self, pool_id: str, **kwargs):
     )
 
 
-@list_request_wrapper
+@request_wrapper
 def pool_relays(self, pool_id: str, **kwargs):
     """
     Relays of a stake pool.

--- a/blockfrost/api/cardano/pools.py
+++ b/blockfrost/api/cardano/pools.py
@@ -284,3 +284,32 @@ def pool_updates(self, pool_id: str, **kwargs):
         params=self.query_parameters(kwargs),
         headers=self.default_headers
     )
+
+
+@list_request_wrapper
+def pool_votes(self, pool_id: str, **kwargs):
+    """
+    History of stake pool votes.
+
+    https://docs.blockfrost.io/#tag/cardano--pools/GET/pools/{pool_id}/votes
+
+    :param pool_id: Bech32 or hexadecimal pool ID.
+    :type pool_id: str
+    :param gather_pages: Optional. Default: false. Will collect all pages into one return
+    :type gather_pages: bool
+    :param count: Optional. Default: 100. The number of results displayed on one page.
+    :type count: int
+    :param page: Optional. The page number for listing the results.
+    :type page: int
+    :param order: Optional. "asc" or "desc". Default: "asc".
+    :type order: str
+    :returns A list of objects.
+    :rtype [Namespace]
+    :raises ApiError: If API fails
+    :raises Exception: If the API response is somehow malformed.
+    """
+    return requests.get(
+        url=f"{self.url}/pools/{pool_id}/votes",
+        params=self.query_parameters(kwargs),
+        headers=self.default_headers
+    )

--- a/blockfrost/api/cardano/scripts.py
+++ b/blockfrost/api/cardano/scripts.py
@@ -7,7 +7,7 @@ def scripts(self, **kwargs):
     """
     List of scripts.
 
-    https://docs.blockfrost.io/#tag/Cardano-Scripts/paths/~1scripts/get
+    https://docs.blockfrost.io/#tag/cardano--scripts/GET/scripts
 
     :param return_type: Optional. "object", "json" or "pandas". Default: "object".
     :type return_type: str
@@ -36,7 +36,7 @@ def script(self, script_hash: str, **kwargs):
     """
     Information about a specific script.
 
-    https://docs.blockfrost.io/#tag/Cardano-Scripts/paths/~1scripts~1{script_hash}/get
+    https://docs.blockfrost.io/#tag/cardano--scripts/GET/scripts/{script_hash}
 
     :param script_hash: Hash of the script.
     :type script_hash: str
@@ -58,7 +58,7 @@ def script_json(self, script_hash: str, **kwargs):
     """
     JSON representation of a timelock script.
 
-    https://docs.blockfrost.io/#tag/Cardano-Scripts/paths/~1scripts~1{script_hash}~1json/get
+    https://docs.blockfrost.io/#tag/cardano--scripts/GET/scripts/{script_hash}/json
 
     :param script_hash: Hash of the script.
     :type script_hash: str
@@ -80,7 +80,7 @@ def script_cbor(self, script_hash: str, **kwargs):
     """
     CBOR representation of a plutus script
 
-    https://docs.blockfrost.io/#tag/Cardano-Scripts/paths/~1scripts~1{script_hash}~1cbor/get
+    https://docs.blockfrost.io/#tag/cardano--scripts/GET/scripts/{script_hash}/cbor
 
     :param script_hash: Hash of the script.
     :type script_hash: str
@@ -102,7 +102,7 @@ def script_redeemers(self, script_hash: str, **kwargs):
     """
     List of redeemers of a specific script.
 
-    https://docs.blockfrost.io/#tag/Cardano-Scripts/paths/~1scripts~1{script_hash}~1redeemers/get
+    https://docs.blockfrost.io/#tag/cardano--scripts/GET/scripts/{script_hash}/redeemers
 
     :param script_hash: Hash of the script.
     :type script_hash: str
@@ -133,7 +133,7 @@ def script_datum(self, datum_hash: str, **kwargs):
     """
     Query JSON value of a datum by its hash.
 
-    https://docs.blockfrost.io/#tag/Cardano-Scripts/paths/~1scripts~1datum~1{datum_hash}/get
+    https://docs.blockfrost.io/#tag/cardano--scripts/GET/scripts/datum/{datum_hash}
 
     :param datum_hash: Hash of the datum.
     :type datum_hash: str
@@ -154,7 +154,7 @@ def script_datum_cbor(self, datum_hash: str, **kwargs):
     """
     Query CBOR value of a datum by its hash.
 
-    https://docs.blockfrost.io/#tag/Cardano-Scripts/paths/~1scripts~1datum~1{datum_hash}~1cbor/get
+    https://docs.blockfrost.io/#tag/cardano--scripts/GET/scripts/datum/{datum_hash}/cbor
 
     :param datum_hash: Hash of the datum.
     :type datum_hash: str

--- a/blockfrost/api/cardano/transactions.py
+++ b/blockfrost/api/cardano/transactions.py
@@ -8,7 +8,7 @@ def transaction(self, hash: str, **kwargs):
     """
     Return content of the requested transaction.
 
-    https://docs.blockfrost.io/#tag/Cardano-Transactions/paths/~1txs~1{hash}/get
+    https://docs.blockfrost.io/#tag/cardano--transactions/GET/txs/{hash}
 
     :param hash: Hash of the requested transaction.
     :type hash: str
@@ -30,7 +30,7 @@ def transaction_utxos(self, hash: str, **kwargs):
     """
     Return the inputs and UTXOs of the specific transaction.
 
-    https://docs.blockfrost.io/#tag/Cardano-Transactions/paths/~1txs~1{hash}~1utxos/get
+    https://docs.blockfrost.io/#tag/cardano--transactions/GET/txs/{hash}/utxos
 
     :param hash: Hash of the requested transaction.
     :type hash: str
@@ -52,7 +52,7 @@ def transaction_stakes(self, hash: str, **kwargs):
     """
     Obtain information about (de)registration of stake addresses within a transaction.
 
-    https://docs.blockfrost.io/#tag/Cardano-Transactions/paths/~1txs~1{hash}~1stakes/get
+    https://docs.blockfrost.io/#tag/cardano--transactions/GET/txs/{hash}/stakes
 
     :param hash: Hash of the requested transaction.
     :type hash: str
@@ -74,7 +74,7 @@ def transaction_delegations(self, hash: str, **kwargs):
     """
     Obtain information about delegation certificates of a specific transaction.
 
-    https://docs.blockfrost.io/#tag/Cardano-Transactions/paths/~1txs~1{hash}~1delegations/get
+    https://docs.blockfrost.io/#tag/cardano--transactions/GET/txs/{hash}/delegations
 
     :param hash: Hash of the requested transaction.
     :type hash: str
@@ -96,7 +96,7 @@ def transaction_withdrawals(self, hash: str, **kwargs):
     """
     Obtain information about withdrawals of a specific transaction.
 
-    https://docs.blockfrost.io/#tag/Cardano-Transactions/paths/~1txs~1{hash}~1withdrawals/get
+    https://docs.blockfrost.io/#tag/cardano--transactions/GET/txs/{hash}/withdrawals
 
     :param hash: Hash of the requested transaction.
     :type hash: str
@@ -118,7 +118,7 @@ def transaction_mirs(self, hash: str, **kwargs):
     """
     Obtain information about Move Instantaneous Rewards (MIRs) of a specific transaction.
 
-    https://docs.blockfrost.io/#tag/Cardano-Transactions/paths/~1txs~1{hash}~1mirs/get
+    https://docs.blockfrost.io/#tag/cardano--transactions/GET/txs/{hash}/mirs
 
     :param hash: Hash of the requested transaction.
     :type hash: str
@@ -140,7 +140,7 @@ def transaction_pool_updates(self, hash: str, **kwargs):
     """
     Obtain information about stake pool registration and update certificates of a specific transaction.
 
-    https://docs.blockfrost.io/#tag/Cardano-Transactions/paths/~1txs~1{hash}~1pool_updates/get
+    https://docs.blockfrost.io/#tag/cardano--transactions/GET/txs/{hash}/pool_updates
 
     :param hash: Hash of the requested transaction.
     :type hash: str
@@ -162,7 +162,7 @@ def transaction_pool_retires(self, hash: str, **kwargs):
     """
     Obtain information about stake pool retirements within a specific transaction.
 
-    https://docs.blockfrost.io/#tag/Cardano-Transactions/paths/~1txs~1{hash}~1pool_retires/get
+    https://docs.blockfrost.io/#tag/cardano--transactions/GET/txs/{hash}/pool_retires
 
     :param hash: Hash of the requested transaction.
     :type hash: str
@@ -184,7 +184,7 @@ def transaction_metadata(self, hash: str, **kwargs):
     """
     Obtain the transaction metadata.
 
-    https://docs.blockfrost.io/#tag/Cardano-Transactions/paths/~1txs~1{hash}~1metadata/get
+    https://docs.blockfrost.io/#tag/cardano--transactions/GET/txs/{hash}/metadata
 
     :param hash: Hash of the requested transaction.
     :type hash: str
@@ -206,7 +206,7 @@ def transaction_metadata_cbor(self, hash: str, **kwargs):
     """
     Obtain the transaction metadata in CBOR.
 
-    https://docs.blockfrost.io/#tag/Cardano-Transactions/paths/~1txs~1{hash}~1metadata~1cbor/get
+    https://docs.blockfrost.io/#tag/cardano--transactions/GET/txs/{hash}/metadata/cbor
 
     :param hash: Hash of the requested transaction.
     :type hash: str
@@ -228,7 +228,7 @@ def transaction_redeemers(self, hash: str, **kwargs):
     """
     Obtain the transaction redeemers.
 
-    https://docs.blockfrost.io/#tag/Cardano-Transactions/paths/~1txs~1{hash}~1redeemers/get
+    https://docs.blockfrost.io/#tag/cardano--transactions/GET/txs/{hash}/redeemers
 
     :param hash: Hash of the requested transaction.
     :type hash: str
@@ -272,7 +272,7 @@ def transaction_cbor(self, hash: str, **kwargs):
     """
     Obtain the transaction in CBOR format.
 
-    https://docs.blockfrost.io/#tag/Cardano-Transactions/paths/~1txs~1{hash}~1cbor/get
+    https://docs.blockfrost.io/#tag/cardano--transactions/GET/txs/{hash}/cbor
 
     :param hash: Hash of the requested transaction.
     :type hash: str
@@ -294,7 +294,7 @@ def transaction_submit(self, file_path: str, **kwargs):
     """
     Submit an already serialized transaction to the network.
 
-    https://docs.blockfrost.io/#tag/Cardano-Transactions/paths/~1tx~1submit/post
+    https://docs.blockfrost.io/#tag/cardano--transactions/POST/tx/submit
 
     :param file_path: Path to file.
     :type file_path: str
@@ -318,7 +318,7 @@ def transaction_submit_cbor(self, tx_cbor: Union[bytes, str], **kwargs):
     """
     Submit an already serialized transaction to the network.
 
-    https://docs.blockfrost.io/#tag/Cardano-Transactions/paths/~1tx~1submit/post
+    https://docs.blockfrost.io/#tag/cardano--transactions/POST/tx/submit
 
     :param tx_cbor: Transaction in CBOR format, either as a hex-encoded string or as bytes.
     :type tx_cbor: Union[str, bytes]
@@ -348,7 +348,7 @@ def transaction_evaluate(self, file_path: str, **kwargs):
     """
     Submit an already serialized transaction to evaluate how much execution units it requires.
 
-    https://docs.blockfrost.io/#tag/Cardano-Utilities/paths/~1utils~1txs~1evaluate/post
+    https://docs.blockfrost.io/#tag/cardano--utilities/POST/utils/txs/evaluate
 
     :param file_path: Path to file.
     :type file_path: str
@@ -372,7 +372,7 @@ def transaction_evaluate_cbor(self, tx_cbor: Union[bytes, str], **kwargs):
     """
     Submit an already serialized transaction to evaluate how much execution units it requires.
 
-    https://docs.blockfrost.io/#tag/Cardano-Utilities/paths/~1utils~1txs~1evaluate/post
+    https://docs.blockfrost.io/#tag/cardano--utilities/POST/utils/txs/evaluate
 
     :param tx_cbor: Transaction in CBOR format, either as a hex-encoded string or as bytes.
     :type tx_cbor: Union[str, bytes]
@@ -402,7 +402,7 @@ def transaction_evaluate_utxos(self, tx_cbor: Union[bytes, str], additional_utxo
     """
     Submits a transaction CBOR and additional utxo set to evaluate how much execution units it requires.
 
-    https://docs.blockfrost.io/#tag/Cardano-Utilities/paths/~1utils~1txs~1evaluate~1utxos/post
+    https://docs.blockfrost.io/#tag/cardano--utilities/POST/utils/txs/evaluate/utxos
     https://ogmios.dev/mini-protocols/local-tx-submission/#evaluatetx
 
     :param tx_cbor: Transaction in CBOR format, either as a hex-encoded string or as bytes.

--- a/blockfrost/api/cardano/transactions.py
+++ b/blockfrost/api/cardano/transactions.py
@@ -1,6 +1,6 @@
 import requests
 from typing import Union
-from blockfrost.utils import request_wrapper, list_request_wrapper
+from blockfrost.utils import request_wrapper
 
 
 @request_wrapper
@@ -47,7 +47,7 @@ def transaction_utxos(self, hash: str, **kwargs):
     )
 
 
-@list_request_wrapper
+@request_wrapper
 def transaction_stakes(self, hash: str, **kwargs):
     """
     Obtain information about (de)registration of stake addresses within a transaction.
@@ -69,7 +69,7 @@ def transaction_stakes(self, hash: str, **kwargs):
     )
 
 
-@list_request_wrapper
+@request_wrapper
 def transaction_delegations(self, hash: str, **kwargs):
     """
     Obtain information about delegation certificates of a specific transaction.
@@ -91,7 +91,7 @@ def transaction_delegations(self, hash: str, **kwargs):
     )
 
 
-@list_request_wrapper
+@request_wrapper
 def transaction_withdrawals(self, hash: str, **kwargs):
     """
     Obtain information about withdrawals of a specific transaction.
@@ -113,7 +113,7 @@ def transaction_withdrawals(self, hash: str, **kwargs):
     )
 
 
-@list_request_wrapper
+@request_wrapper
 def transaction_mirs(self, hash: str, **kwargs):
     """
     Obtain information about Move Instantaneous Rewards (MIRs) of a specific transaction.
@@ -135,7 +135,7 @@ def transaction_mirs(self, hash: str, **kwargs):
     )
 
 
-@list_request_wrapper
+@request_wrapper
 def transaction_pool_updates(self, hash: str, **kwargs):
     """
     Obtain information about stake pool registration and update certificates of a specific transaction.
@@ -157,7 +157,7 @@ def transaction_pool_updates(self, hash: str, **kwargs):
     )
 
 
-@list_request_wrapper
+@request_wrapper
 def transaction_pool_retires(self, hash: str, **kwargs):
     """
     Obtain information about stake pool retirements within a specific transaction.
@@ -179,7 +179,7 @@ def transaction_pool_retires(self, hash: str, **kwargs):
     )
 
 
-@list_request_wrapper
+@request_wrapper
 def transaction_metadata(self, hash: str, **kwargs):
     """
     Obtain the transaction metadata.
@@ -201,7 +201,7 @@ def transaction_metadata(self, hash: str, **kwargs):
     )
 
 
-@list_request_wrapper
+@request_wrapper
 def transaction_metadata_cbor(self, hash: str, **kwargs):
     """
     Obtain the transaction metadata in CBOR.
@@ -223,7 +223,7 @@ def transaction_metadata_cbor(self, hash: str, **kwargs):
     )
 
 
-@list_request_wrapper
+@request_wrapper
 def transaction_redeemers(self, hash: str, **kwargs):
     """
     Obtain the transaction redeemers.

--- a/blockfrost/api/cardano/transactions.py
+++ b/blockfrost/api/cardano/transactions.py
@@ -245,6 +245,50 @@ def transaction_redeemers(self, hash: str, **kwargs):
     )
 
 
+@list_request_wrapper
+def transaction_required_signers(self, hash: str, **kwargs):
+    """
+    Obtain the required signers of a specific transaction.
+
+    https://docs.blockfrost.io/#tag/Cardano-Transactions/paths/~1txs~1{hash}~1required_signers/get
+
+    :param hash: Hash of the requested transaction.
+    :type hash: str
+    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
+    :type return_type: str
+    :returns A list of objects.
+    :rtype [Namespace]
+    :raises ApiError: If API fails
+    :raises Exception: If the API response is somehow malformed.
+    """
+    return requests.get(
+        url=f"{self.url}/txs/{hash}/required_signers",
+        headers=self.default_headers
+    )
+
+
+@request_wrapper
+def transaction_cbor(self, hash: str, **kwargs):
+    """
+    Obtain the transaction in CBOR format.
+
+    https://docs.blockfrost.io/#tag/Cardano-Transactions/paths/~1txs~1{hash}~1cbor/get
+
+    :param hash: Hash of the requested transaction.
+    :type hash: str
+    :param return_type: Optional. "object", "json" or "pandas". Default: "object".
+    :type return_type: str
+    :returns object.
+    :rtype: Namespace
+    :raises ApiError: If API fails
+    :raises Exception: If the API response is somehow malformed.
+    """
+    return requests.get(
+        url=f"{self.url}/txs/{hash}/cbor",
+        headers=self.default_headers
+    )
+
+
 @request_wrapper
 def transaction_submit(self, file_path: str, **kwargs):
     """

--- a/blockfrost/api/cardano/transactions.py
+++ b/blockfrost/api/cardano/transactions.py
@@ -245,12 +245,12 @@ def transaction_redeemers(self, hash: str, **kwargs):
     )
 
 
-@list_request_wrapper
+@request_wrapper
 def transaction_required_signers(self, hash: str, **kwargs):
     """
     Obtain the required signers of a specific transaction.
 
-    https://docs.blockfrost.io/#tag/Cardano-Transactions/paths/~1txs~1{hash}~1required_signers/get
+    https://docs.blockfrost.io/#tag/cardano--transactions/GET/txs/{hash}/required_signers
 
     :param hash: Hash of the requested transaction.
     :type hash: str

--- a/blockfrost/api/cardano/utils.py
+++ b/blockfrost/api/cardano/utils.py
@@ -7,7 +7,7 @@ def utils_addresses_xpub(self, xpub: str, role: int, index: int, **kwargs):
     """
     Derive Shelley address from an xpub
 
-    https://docs.blockfrost.io/#tag/Cardano-Utilities/paths/~1utils~1addresses~1xpub~1{xpub}~1{role}~1{index}/get
+    https://docs.blockfrost.io/#tag/cardano--utilities/GET/utils/addresses/xpub/{xpub}/{role}/{index}
 
     :param xpub: Hex xpub.
     :type xpub: str

--- a/blockfrost/api/health.py
+++ b/blockfrost/api/health.py
@@ -7,7 +7,7 @@ def health(self, **kwargs):
     """
     Return backend status as a boolean. Your application should handle situations when backend for the given chain is unavailable.
 
-    https://docs.blockfrost.io/#tag/Health/paths/~1health/get
+    https://docs.blockfrost.io/#tag/health/GET/health
 
     :param return_type: Optional. "object", "json" or "pandas". Default: "object".
     :type return_type: str
@@ -27,7 +27,7 @@ def clock(self, **kwargs):
     """
     This endpoint provides the current UNIX time. Your application might use this to verify if the client clock is not out of sync.
 
-    https://docs.blockfrost.io/#tag/Health/paths/~1health~1clock/get
+    https://docs.blockfrost.io/#tag/health/GET/health/clock
 
     :param return_type: Optional. "object", "json" or "pandas". Default: "object".
     :type return_type: str

--- a/blockfrost/api/metrics.py
+++ b/blockfrost/api/metrics.py
@@ -8,7 +8,7 @@ def metrics(self, **kwargs):
     """
     History of your Blockfrost usage metrics in the past 30 days.
 
-    https://docs.blockfrost.io/#tag/Metrics/paths/~1metrics~1/get
+    https://docs.blockfrost.io/#tag/metrics/GET/metrics
 
     :param return_type: Optional. "object", "json" or "pandas". Default: "object".
     :type return_type: str
@@ -28,7 +28,7 @@ def metrics_endpoints(self, **kwargs):
     """
     History of your Blockfrost usage metrics per endpoint in the past 30 days.
 
-    https://docs.blockfrost.io/#tag/Metrics/paths/~1metrics~1endpoints/get
+    https://docs.blockfrost.io/#tag/metrics/GET/metrics/endpoints
 
     :param return_type: Optional. "object", "json" or "pandas". Default: "object".
     :type return_type: str

--- a/blockfrost/api/metrics.py
+++ b/blockfrost/api/metrics.py
@@ -1,9 +1,9 @@
 import requests
 from dataclasses import dataclass
-from ..utils import list_request_wrapper
+from ..utils import request_wrapper
 
 
-@list_request_wrapper
+@request_wrapper
 def metrics(self, **kwargs):
     """
     History of your Blockfrost usage metrics in the past 30 days.
@@ -23,7 +23,7 @@ def metrics(self, **kwargs):
     )
 
 
-@list_request_wrapper
+@request_wrapper
 def metrics_endpoints(self, **kwargs):
     """
     History of your Blockfrost usage metrics per endpoint in the past 30 days.

--- a/blockfrost/api/metrics.py
+++ b/blockfrost/api/metrics.py
@@ -1,5 +1,4 @@
 import requests
-from dataclasses import dataclass
 from ..utils import request_wrapper
 
 

--- a/blockfrost/api/nutlink.py
+++ b/blockfrost/api/nutlink.py
@@ -30,7 +30,7 @@ def nutlink_address_tickers(self, address: str, **kwargs):
     """
     List tickers for a specific metadata oracle
 
-    https://docs.blockfrost.io/#tag/Nut.link/paths/~1nutlink~1{address}~1tickers/get
+    https://docs.blockfrost.io/#tag/nut.link/GET/nutlink/{address}/tickers
 
     :param address: Address of a metadata oracle.
     :type address: str
@@ -61,7 +61,7 @@ def nutlink_address_ticker(self, address: str, ticker: str, **kwargs):
     """
     List of records of a specific ticker
 
-    https://docs.blockfrost.io/#tag/Nut.link/paths/~1nutlink~1{address}~1tickers~1{ticker}/get
+    https://docs.blockfrost.io/#tag/nut.link/GET/nutlink/{address}/tickers/{ticker}
 
     :param address: Address of a metadata oracle.
     :type address: str
@@ -94,7 +94,7 @@ def nutlink_ticker(self, ticker: str, **kwargs):
     """
     List of records of a specific ticker
 
-    https://docs.blockfrost.io/#tag/Nut.link/paths/~1nutlink~1tickers~1{ticker}/get
+    https://docs.blockfrost.io/#tag/nut.link/GET/nutlink/tickers/{ticker}
 
     :param ticker: Ticker for the pool record.
     :type ticker: str

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (HERE / 'README.md').read_text(encoding='utf-8')
 setup(
     name='blockfrost-python',
     version='0.7.0',
-    description='The official Python SDK for Blockfrost API v0.1.85',
+    description='The official Python SDK for Blockfrost API v0.1.86',
     long_description=long_description,
     long_description_content_type='text/markdown',
     url='https://github.com/blockfrost/blockfrost-python',

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ long_description = (HERE / 'README.md').read_text(encoding='utf-8')
 
 setup(
     name='blockfrost-python',
-    version='0.6.0',
-    description='The official Python SDK for Blockfrost API v0.1.37',
+    version='0.7.0',
+    description='The official Python SDK for Blockfrost API v0.1.85',
     long_description=long_description,
     long_description_content_type='text/markdown',
     url='https://github.com/blockfrost/blockfrost-python',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     license='Apache-2.0',
     keywords='blockfrost blockchain cardano ipfs',
     packages=find_packages(exclude=['tests', 'tests.*']),
-    python_requires='>=3.7, <4',
+    python_requires='>=3.10, <4',
     requires=[
         "importlib_metadata",
     ],
@@ -48,10 +48,9 @@ setup(
         'License :: OSI Approved :: Apache Software License',
 
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Programming Language :: Python :: 3 :: Only',
     ],
 )

--- a/tests/test_cardano_accounts.py
+++ b/tests/test_cardano_accounts.py
@@ -243,6 +243,61 @@ def test_integration_account_addresses_assets():
         assert api.account_addresses_assets(stake_address=stake_address) == []
 
 
+def test_account_utxos(requests_mock):
+    api = BlockFrostApi()
+    mock_data = [
+        {
+            "address": "addr1qx2kd28nq8ac5prwg32hhvudlwggpgfp8utlyqxu6wqgz62f79qsdmm5dsknt9ecr5w468r9ey0fxwkdrwh08ly3tu9sy0f4qd",
+            "tx_hash": "39a7a284c2a0c3a6d5f594f2bd150c2f13c6b2a1f8a1e3d5c0f3b2a1d0e9f8a7",
+            "output_index": 0,
+            "amount": [
+                {
+                    "unit": "lovelace",
+                    "quantity": "42000000"
+                }
+            ],
+            "block": "7eb8e27d18686c7db9a18f8bbcfe34e3fed6e047afaa2d969904d15e934847e6",
+            "data_hash": None,
+            "inline_datum": None,
+            "reference_script_hash": None
+        }
+    ]
+    requests_mock.get(f"{api.url}/accounts/{stake_address}/utxos", json=mock_data)
+    assert api.account_utxos(stake_address=stake_address) == convert_json_to_object(mock_data)
+
+
+def test_integration_account_utxos():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
+        api.account_utxos(stake_address=stake_address)
+
+
+def test_account_transactions(requests_mock):
+    api = BlockFrostApi()
+    mock_data = [
+        {
+            "tx_hash": "8788591983aa73981fc92d6cddbbe643959f5a784e84b8bee0db15823f575a5b",
+            "tx_index": 6,
+            "block_height": 69,
+            "block_time": 1635505891
+        },
+        {
+            "tx_hash": "52e748c4dec58b687b90b0b40d383b9fe1f24c1a833b7395cdf07dd67859f46f",
+            "tx_index": 9,
+            "block_height": 4547,
+            "block_time": 1635505987
+        }
+    ]
+    requests_mock.get(f"{api.url}/accounts/{stake_address}/transactions", json=mock_data)
+    assert api.account_transactions(stake_address=stake_address) == convert_json_to_object(mock_data)
+
+
+def test_integration_account_transactions():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
+        api.account_transactions(stake_address=stake_address)
+
+
 def test_account_addresses_total(requests_mock):
     api = BlockFrostApi()
     mock_data = {

--- a/tests/test_cardano_blocks.py
+++ b/tests/test_cardano_blocks.py
@@ -223,6 +223,47 @@ def test_integration_block_transactions():
         assert api.block_transactions(hash_or_number=hash)
 
 
+def test_block_latest_transactions_cbor(requests_mock):
+    api = BlockFrostApi()
+    mock_data = [
+        {
+            "tx_hash": "8788591983aa73981fc92d6cddbbe643959f5a784e84b8bee0db15823f575a5b",
+            "cbor": "84a8008282582098483df1666d5af7c4aca7ef28f112d225b81a34ef20b0ad4775bab0e41dbb30"
+        },
+        {
+            "tx_hash": "4eef6bb7755d8afbeac526b799f3e32a624691d166657e9d862aaeb66682c036",
+            "cbor": "84a8008282582098483df1666d5af7c4aca7ef28f112d225b81a34ef20b0ad4775bab0e41dbb31"
+        }
+    ]
+    requests_mock.get(f"{api.url}/blocks/latest/txs/cbor", json=mock_data)
+    assert api.block_latest_transactions_cbor() == convert_json_to_object(mock_data)
+
+
+def test_integration_block_latest_transactions_cbor():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
+        assert (api.block_latest_transactions_cbor() or
+                api.block_latest_transactions_cbor() == [])
+
+
+def test_block_transactions_cbor(requests_mock):
+    api = BlockFrostApi()
+    mock_data = [
+        {
+            "tx_hash": "8788591983aa73981fc92d6cddbbe643959f5a784e84b8bee0db15823f575a5b",
+            "cbor": "84a8008282582098483df1666d5af7c4aca7ef28f112d225b81a34ef20b0ad4775bab0e41dbb30"
+        }
+    ]
+    requests_mock.get(f"{api.url}/blocks/{hash}/txs/cbor", json=mock_data)
+    assert api.block_transactions_cbor(hash_or_number=hash) == convert_json_to_object(mock_data)
+
+
+def test_integration_block_transactions_cbor():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
+        assert api.block_transactions_cbor(hash_or_number=hash)
+
+
 def test_blocks_blocks_addresses(requests_mock):
     api = BlockFrostApi()
     mock_data = [

--- a/tests/test_cardano_blocks.py
+++ b/tests/test_cardano_blocks.py
@@ -242,8 +242,8 @@ def test_block_latest_transactions_cbor(requests_mock):
 def test_integration_block_latest_transactions_cbor():
     if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
         api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
-        assert (api.block_latest_transactions_cbor() or
-                api.block_latest_transactions_cbor() == [])
+        result = api.block_latest_transactions_cbor()
+        assert result or result == []
 
 
 def test_block_transactions_cbor(requests_mock):

--- a/tests/test_cardano_governance.py
+++ b/tests/test_cardano_governance.py
@@ -1,0 +1,268 @@
+import os
+from blockfrost import BlockFrostApi, ApiError
+from blockfrost.utils import convert_json_to_object
+
+drep_id = 'drep1mvdu8slennngja7w4un6knwezufra70887zuxpprd64jxfveahn'
+tx_hash = 'f5ca33220afcc0340d1fa3cba9b0e1f3c3c6e1eab57d688ed700ae56bbce9170'
+cert_index = 0
+
+
+def test_governance_dreps(requests_mock):
+    api = BlockFrostApi()
+    mock_data = [
+        {
+            "drep_id": drep_id,
+            "hex": "db1bc3c3f99fd22aa1e09f1c34c0ada5795c5e1f32f2652a246f73db"
+        },
+        {
+            "drep_id": "drep1cxayn4fgy27yaucvhamsvqj3v6835mh3tjjx6t8rm65ndd3lcjm",
+            "hex": "c1d932a9a0457a13bc6195f7600c919d1e3476f715c86d2c8f7a9a66"
+        }
+    ]
+    requests_mock.get(f"{api.url}/governance/dreps", json=mock_data)
+    assert api.governance_dreps() == convert_json_to_object(mock_data)
+
+
+def test_integration_governance_dreps():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
+        api.governance_dreps()
+
+
+def test_governance_drep(requests_mock):
+    api = BlockFrostApi()
+    mock_data = {
+        "drep_id": drep_id,
+        "hex": "db1bc3c3f99fd22aa1e09f1c34c0ada5795c5e1f32f2652a246f73db",
+        "amount": "2000000",
+        "active": True,
+        "active_epoch": 420,
+        "has_script": False,
+        "retired": False,
+        "expired": False,
+        "last_active_epoch": 500
+    }
+    requests_mock.get(f"{api.url}/governance/dreps/{drep_id}", json=mock_data)
+    assert api.governance_drep(drep_id=drep_id) == convert_json_to_object(mock_data)
+
+
+def test_integration_governance_drep():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
+        api.governance_drep(drep_id=drep_id)
+
+
+def test_governance_drep_delegators(requests_mock):
+    api = BlockFrostApi()
+    mock_data = [
+        {
+            "address": "stake1ux3g2c9dx2nhhehyrezyxpkstartcqmu9hk63qgfkccw5rqttygt7",
+            "amount": "1029328"
+        }
+    ]
+    requests_mock.get(f"{api.url}/governance/dreps/{drep_id}/delegators", json=mock_data)
+    assert api.governance_drep_delegators(drep_id=drep_id) == convert_json_to_object(mock_data)
+
+
+def test_integration_governance_drep_delegators():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
+        api.governance_drep_delegators(drep_id=drep_id)
+
+
+def test_governance_drep_metadata(requests_mock):
+    api = BlockFrostApi()
+    mock_data = {
+        "drep_id": drep_id,
+        "hex": "db1bc3c3f99fd22aa1e09f1c34c0ada5795c5e1f32f2652a246f73db",
+        "url": "https://example.com/drep-metadata.json",
+        "hash": "a14a5ad4a83b1c8b04c5175f0a16b4a2d8b1e5a08c7b6d1e2f3c4d5e6f7a8b9",
+        "json_metadata": None,
+        "bytes": "\\xa100"
+    }
+    requests_mock.get(f"{api.url}/governance/dreps/{drep_id}/metadata", json=mock_data)
+    assert api.governance_drep_metadata(drep_id=drep_id) == convert_json_to_object(mock_data)
+
+
+def test_integration_governance_drep_metadata():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
+        api.governance_drep_metadata(drep_id=drep_id)
+
+
+def test_governance_drep_updates(requests_mock):
+    api = BlockFrostApi()
+    mock_data = [
+        {
+            "tx_hash": "f5ca33220afcc0340d1fa3cba9b0e1f3c3c6e1eab57d688ed700ae56bbce9170",
+            "cert_index": 0,
+            "action": "registered"
+        },
+        {
+            "tx_hash": "0e98ac6a8b1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7",
+            "cert_index": 0,
+            "action": "updated"
+        }
+    ]
+    requests_mock.get(f"{api.url}/governance/dreps/{drep_id}/updates", json=mock_data)
+    assert api.governance_drep_updates(drep_id=drep_id) == convert_json_to_object(mock_data)
+
+
+def test_integration_governance_drep_updates():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
+        api.governance_drep_updates(drep_id=drep_id)
+
+
+def test_governance_drep_votes(requests_mock):
+    api = BlockFrostApi()
+    mock_data = [
+        {
+            "tx_hash": "f5ca33220afcc0340d1fa3cba9b0e1f3c3c6e1eab57d688ed700ae56bbce9170",
+            "cert_index": 0,
+            "vote": "yes",
+            "proposal_tx_hash": "b302de9b2ed2bca4d65e40cae4ae6d0b8e7c0f1a2b3c4d5e6f7a8b9c0d1e2f3a",
+            "proposal_cert_index": 0
+        }
+    ]
+    requests_mock.get(f"{api.url}/governance/dreps/{drep_id}/votes", json=mock_data)
+    assert api.governance_drep_votes(drep_id=drep_id) == convert_json_to_object(mock_data)
+
+
+def test_integration_governance_drep_votes():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
+        api.governance_drep_votes(drep_id=drep_id)
+
+
+def test_governance_proposals(requests_mock):
+    api = BlockFrostApi()
+    mock_data = [
+        {
+            "tx_hash": tx_hash,
+            "cert_index": cert_index,
+            "governance_type": "treasury_withdrawals",
+            "deposit": "100000000000",
+            "return_address": "stake1ux3g2c9dx2nhhehyrezyxpkstartcqmu9hk63qgfkccw5rqttygt7",
+            "governance_description": None,
+            "ratified_epoch": None,
+            "enacted_epoch": None,
+            "dropped_epoch": None,
+            "expired_epoch": None,
+            "expiration": 550
+        }
+    ]
+    requests_mock.get(f"{api.url}/governance/proposals", json=mock_data)
+    assert api.governance_proposals() == convert_json_to_object(mock_data)
+
+
+def test_integration_governance_proposals():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
+        api.governance_proposals()
+
+
+def test_governance_proposal(requests_mock):
+    api = BlockFrostApi()
+    mock_data = {
+        "tx_hash": tx_hash,
+        "cert_index": cert_index,
+        "governance_type": "treasury_withdrawals",
+        "deposit": "100000000000",
+        "return_address": "stake1ux3g2c9dx2nhhehyrezyxpkstartcqmu9hk63qgfkccw5rqttygt7",
+        "governance_description": None,
+        "ratified_epoch": None,
+        "enacted_epoch": None,
+        "dropped_epoch": None,
+        "expired_epoch": None,
+        "expiration": 550
+    }
+    requests_mock.get(f"{api.url}/governance/proposals/{tx_hash}/{cert_index}", json=mock_data)
+    assert api.governance_proposal(tx_hash=tx_hash, cert_index=cert_index) == convert_json_to_object(mock_data)
+
+
+def test_integration_governance_proposal():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
+        api.governance_proposal(tx_hash=tx_hash, cert_index=cert_index)
+
+
+def test_governance_proposal_parameters(requests_mock):
+    api = BlockFrostApi()
+    mock_data = {
+        "tx_hash": tx_hash,
+        "cert_index": cert_index,
+        "parameters": {
+            "min_fee_a": 44,
+            "min_fee_b": 155381,
+            "key_deposit": "2000000",
+            "pool_deposit": "500000000"
+        }
+    }
+    requests_mock.get(f"{api.url}/governance/proposals/{tx_hash}/{cert_index}/parameters", json=mock_data)
+    assert api.governance_proposal_parameters(tx_hash=tx_hash, cert_index=cert_index) == convert_json_to_object(mock_data)
+
+
+def test_integration_governance_proposal_parameters():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
+        api.governance_proposal_parameters(tx_hash=tx_hash, cert_index=cert_index)
+
+
+def test_governance_proposal_withdrawals(requests_mock):
+    api = BlockFrostApi()
+    mock_data = [
+        {
+            "stake_address": "stake1ux3g2c9dx2nhhehyrezyxpkstartcqmu9hk63qgfkccw5rqttygt7",
+            "amount": "454541212442"
+        }
+    ]
+    requests_mock.get(f"{api.url}/governance/proposals/{tx_hash}/{cert_index}/withdrawals", json=mock_data)
+    assert api.governance_proposal_withdrawals(tx_hash=tx_hash, cert_index=cert_index) == convert_json_to_object(mock_data)
+
+
+def test_integration_governance_proposal_withdrawals():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
+        api.governance_proposal_withdrawals(tx_hash=tx_hash, cert_index=cert_index)
+
+
+def test_governance_proposal_votes(requests_mock):
+    api = BlockFrostApi()
+    mock_data = [
+        {
+            "tx_hash": "f5ca33220afcc0340d1fa3cba9b0e1f3c3c6e1eab57d688ed700ae56bbce9170",
+            "cert_index": 0,
+            "voter": "drep1mvdu8slennngja7w4un6knwezufra70887zuxpprd64jxfveahn",
+            "voter_role": "drep",
+            "vote": "yes"
+        }
+    ]
+    requests_mock.get(f"{api.url}/governance/proposals/{tx_hash}/{cert_index}/votes", json=mock_data)
+    assert api.governance_proposal_votes(tx_hash=tx_hash, cert_index=cert_index) == convert_json_to_object(mock_data)
+
+
+def test_integration_governance_proposal_votes():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
+        api.governance_proposal_votes(tx_hash=tx_hash, cert_index=cert_index)
+
+
+def test_governance_proposal_metadata(requests_mock):
+    api = BlockFrostApi()
+    mock_data = {
+        "tx_hash": tx_hash,
+        "cert_index": cert_index,
+        "url": "https://example.com/proposal-metadata.json",
+        "hash": "a14a5ad4a83b1c8b04c5175f0a16b4a2d8b1e5a08c7b6d1e2f3c4d5e6f7a8b9",
+        "json_metadata": None,
+        "bytes": "\\xa100"
+    }
+    requests_mock.get(f"{api.url}/governance/proposals/{tx_hash}/{cert_index}/metadata", json=mock_data)
+    assert api.governance_proposal_metadata(tx_hash=tx_hash, cert_index=cert_index) == convert_json_to_object(mock_data)
+
+
+def test_integration_governance_proposal_metadata():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
+        api.governance_proposal_metadata(tx_hash=tx_hash, cert_index=cert_index)

--- a/tests/test_cardano_governance.py
+++ b/tests/test_cardano_governance.py
@@ -7,6 +7,7 @@ tx_hash = '51f495aa23f4b3b3aa90afde4a0e67823bb7ac4ac65f5ffbb138373b863f2f74'
 cert_index = 0
 # proposal with metadata (treasury_withdrawals type)
 metadata_tx_hash = '60ed6ab43c840ff888a8af30a1ed27b41e9f4a91a89822b2b63d1bfc52aeec45'
+gov_action_id = 'gov_action1zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygsq6dmejn'
 
 
 def test_governance_dreps(requests_mock):
@@ -268,3 +269,109 @@ def test_integration_governance_proposal_metadata():
     if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
         api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
         api.governance_proposal_metadata(tx_hash=metadata_tx_hash, cert_index=cert_index)
+
+
+def test_governance_proposal_by_gov_action_id(requests_mock):
+    api = BlockFrostApi()
+    mock_data = {
+        "tx_hash": tx_hash,
+        "cert_index": cert_index,
+        "governance_type": "treasury_withdrawals",
+        "deposit": "100000000000",
+        "return_address": "stake1ux3g2c9dx2nhhehyrezyxpkstartcqmu9hk63qgfkccw5rqttygt7",
+        "governance_description": None,
+        "ratified_epoch": None,
+        "enacted_epoch": None,
+        "dropped_epoch": None,
+        "expired_epoch": None,
+        "expiration": 550
+    }
+    requests_mock.get(f"{api.url}/governance/proposals/{gov_action_id}", json=mock_data)
+    assert api.governance_proposal_by_gov_action_id(gov_action_id=gov_action_id) == convert_json_to_object(mock_data)
+
+
+def test_integration_governance_proposal_by_gov_action_id():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
+        api.governance_proposal_by_gov_action_id(gov_action_id=gov_action_id)
+
+
+def test_governance_proposal_parameters_by_gov_action_id(requests_mock):
+    api = BlockFrostApi()
+    mock_data = {
+        "tx_hash": tx_hash,
+        "cert_index": cert_index,
+        "parameters": {
+            "min_fee_a": 44,
+            "min_fee_b": 155381,
+            "key_deposit": "2000000",
+            "pool_deposit": "500000000"
+        }
+    }
+    requests_mock.get(f"{api.url}/governance/proposals/{gov_action_id}/parameters", json=mock_data)
+    assert api.governance_proposal_parameters_by_gov_action_id(gov_action_id=gov_action_id) == convert_json_to_object(mock_data)
+
+
+def test_integration_governance_proposal_parameters_by_gov_action_id():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
+        api.governance_proposal_parameters_by_gov_action_id(gov_action_id=gov_action_id)
+
+
+def test_governance_proposal_withdrawals_by_gov_action_id(requests_mock):
+    api = BlockFrostApi()
+    mock_data = [
+        {
+            "stake_address": "stake1ux3g2c9dx2nhhehyrezyxpkstartcqmu9hk63qgfkccw5rqttygt7",
+            "amount": "454541212442"
+        }
+    ]
+    requests_mock.get(f"{api.url}/governance/proposals/{gov_action_id}/withdrawals", json=mock_data)
+    assert api.governance_proposal_withdrawals_by_gov_action_id(gov_action_id=gov_action_id) == convert_json_to_object(mock_data)
+
+
+def test_integration_governance_proposal_withdrawals_by_gov_action_id():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
+        api.governance_proposal_withdrawals_by_gov_action_id(gov_action_id=gov_action_id)
+
+
+def test_governance_proposal_votes_by_gov_action_id(requests_mock):
+    api = BlockFrostApi()
+    mock_data = [
+        {
+            "tx_hash": "f5ca33220afcc0340d1fa3cba9b0e1f3c3c6e1eab57d688ed700ae56bbce9170",
+            "cert_index": 0,
+            "voter": "drep1mvdu8slennngja7w4un6knwezufra70887zuxpprd64jxfveahn",
+            "voter_role": "drep",
+            "vote": "yes"
+        }
+    ]
+    requests_mock.get(f"{api.url}/governance/proposals/{gov_action_id}/votes", json=mock_data)
+    assert api.governance_proposal_votes_by_gov_action_id(gov_action_id=gov_action_id) == convert_json_to_object(mock_data)
+
+
+def test_integration_governance_proposal_votes_by_gov_action_id():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
+        api.governance_proposal_votes_by_gov_action_id(gov_action_id=gov_action_id)
+
+
+def test_governance_proposal_metadata_by_gov_action_id(requests_mock):
+    api = BlockFrostApi()
+    mock_data = {
+        "tx_hash": tx_hash,
+        "cert_index": cert_index,
+        "url": "https://example.com/proposal-metadata.json",
+        "hash": "a14a5ad4a83b1c8b04c5175f0a16b4a2d8b1e5a08c7b6d1e2f3c4d5e6f7a8b9",
+        "json_metadata": None,
+        "bytes": "\\xa100"
+    }
+    requests_mock.get(f"{api.url}/governance/proposals/{gov_action_id}/metadata", json=mock_data)
+    assert api.governance_proposal_metadata_by_gov_action_id(gov_action_id=gov_action_id) == convert_json_to_object(mock_data)
+
+
+def test_integration_governance_proposal_metadata_by_gov_action_id():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
+        api.governance_proposal_metadata_by_gov_action_id(gov_action_id=gov_action_id)

--- a/tests/test_cardano_governance.py
+++ b/tests/test_cardano_governance.py
@@ -1,5 +1,5 @@
 import os
-from blockfrost import BlockFrostApi, ApiError
+from blockfrost import BlockFrostApi
 from blockfrost.utils import convert_json_to_object
 
 drep_id = 'drep1yfaaaaa270yjt6tu5skndugekprf5ykv5jshanl0c6gqx5qpstskf'

--- a/tests/test_cardano_governance.py
+++ b/tests/test_cardano_governance.py
@@ -2,9 +2,11 @@ import os
 from blockfrost import BlockFrostApi, ApiError
 from blockfrost.utils import convert_json_to_object
 
-drep_id = 'drep1mvdu8slennngja7w4un6knwezufra70887zuxpprd64jxfveahn'
-tx_hash = 'f5ca33220afcc0340d1fa3cba9b0e1f3c3c6e1eab57d688ed700ae56bbce9170'
+drep_id = 'drep1yfaaaaa270yjt6tu5skndugekprf5ykv5jshanl0c6gqx5qpstskf'
+tx_hash = '51f495aa23f4b3b3aa90afde4a0e67823bb7ac4ac65f5ffbb138373b863f2f74'
 cert_index = 0
+# proposal with metadata (treasury_withdrawals type)
+metadata_tx_hash = '60ed6ab43c840ff888a8af30a1ed27b41e9f4a91a89822b2b63d1bfc52aeec45'
 
 
 def test_governance_dreps(requests_mock):
@@ -265,4 +267,4 @@ def test_governance_proposal_metadata(requests_mock):
 def test_integration_governance_proposal_metadata():
     if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
         api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
-        api.governance_proposal_metadata(tx_hash=tx_hash, cert_index=cert_index)
+        api.governance_proposal_metadata(tx_hash=metadata_tx_hash, cert_index=cert_index)

--- a/tests/test_cardano_network.py
+++ b/tests/test_cardano_network.py
@@ -27,3 +27,51 @@ def test_integration_network():
     if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
         api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
         assert api.network()
+
+
+def test_network_eras(requests_mock):
+    api = BlockFrostApi()
+    mock_data = [
+        {
+            "start": {
+                "time": 0,
+                "slot": 0,
+                "epoch": 0
+            },
+            "end": {
+                "time": 89856000,
+                "slot": 4492800,
+                "epoch": 208
+            },
+            "parameters": {
+                "epoch_length": 21600,
+                "slot_length": 20,
+                "safe_zone": 4320
+            }
+        },
+        {
+            "start": {
+                "time": 89856000,
+                "slot": 4492800,
+                "epoch": 208
+            },
+            "end": {
+                "time": 101952000,
+                "slot": 16588800,
+                "epoch": 236
+            },
+            "parameters": {
+                "epoch_length": 432000,
+                "slot_length": 1,
+                "safe_zone": 129600
+            }
+        }
+    ]
+    requests_mock.get(f"{api.url}/network/eras", json=mock_data)
+    assert api.network_eras() == convert_json_to_object(mock_data)
+
+
+def test_integration_network_eras():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
+        assert api.network_eras()

--- a/tests/test_cardano_pools.py
+++ b/tests/test_cardano_pools.py
@@ -301,4 +301,4 @@ def test_pool_votes(requests_mock):
 def test_integration_pool_votes():
     if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
         api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
-        api.pool_votes(pool_id=pool_id)
+        assert api.pool_votes(pool_id=pool_id) or api.pool_votes(pool_id=pool_id) == []

--- a/tests/test_cardano_pools.py
+++ b/tests/test_cardano_pools.py
@@ -281,3 +281,24 @@ def test_integration_pool_updates():
     if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
         api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
         assert api.pool_updates(pool_id=pool_id)
+
+
+def test_pool_votes(requests_mock):
+    api = BlockFrostApi()
+    mock_data = [
+        {
+            "tx_hash": "f5ca33220afcc0340d1fa3cba9b0e1f3c3c6e1eab57d688ed700ae56bbce9170",
+            "cert_index": 0,
+            "vote": "yes",
+            "proposal_tx_hash": "b302de9b2ed2bca4d65e40cae4ae6d0b8e7c0f1a2b3c4d5e6f7a8b9c0d1e2f3a",
+            "proposal_cert_index": 0
+        }
+    ]
+    requests_mock.get(f"{api.url}/pools/{pool_id}/votes", json=mock_data)
+    assert api.pool_votes(pool_id=pool_id) == convert_json_to_object(mock_data)
+
+
+def test_integration_pool_votes():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'))
+        api.pool_votes(pool_id=pool_id)

--- a/tests/test_cardano_transactions.py
+++ b/tests/test_cardano_transactions.py
@@ -361,6 +361,42 @@ def test_integration_transaction_redeemers():
         assert api.transaction_redeemers(hash=hash) == []
 
 
+def test_transaction_required_signers(requests_mock):
+    api = BlockFrostApi()
+    mock_data = [
+        {
+            "address": "ec26b89af41bef0f7585353831cb5da42b5b37185e0c8a526143b824"
+        }
+    ]
+    requests_mock.get(f"{api.url}/txs/{hash}/required_signers", json=mock_data)
+    assert api.transaction_required_signers(
+        hash=hash) == convert_json_to_object(mock_data)
+
+
+def test_integration_transaction_required_signers():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv(
+            'BLOCKFROST_PROJECT_ID_MAINNET'))
+        assert api.transaction_required_signers(hash=hash) == []
+
+
+def test_transaction_cbor(requests_mock):
+    api = BlockFrostApi()
+    mock_data = {
+        "cbor": "84a8008282582098483df1666d5af7c4aca7ef28f112d225b81a34ef20b0ad4775bab0e41dbb30"
+    }
+    requests_mock.get(f"{api.url}/txs/{hash}/cbor", json=mock_data)
+    assert api.transaction_cbor(
+        hash=hash) == convert_json_to_object(mock_data)
+
+
+def test_integration_transaction_cbor():
+    if os.getenv('BLOCKFROST_PROJECT_ID_MAINNET'):
+        api = BlockFrostApi(project_id=os.getenv(
+            'BLOCKFROST_PROJECT_ID_MAINNET'))
+        assert api.transaction_cbor(hash=hash)
+
+
 def test_transaction_submit(requests_mock):
     api = BlockFrostApi()
     mock_data = hash

--- a/tests/test_cardano_transactions.py
+++ b/tests/test_cardano_transactions.py
@@ -412,7 +412,7 @@ def test_integration_transaction_submit_cbor():
 
         with pytest.raises(ApiError) as exc_info:
             api.transaction_submit_cbor(tx_cbor=tx_cbor)
-        assert exc_info.value.message.find("transaction submit error") > -1
+        assert exc_info.value.status_code == 400
         # Make sure that the tx cbor was correctly passed
         assert exc_info.value.message.find(
             "54bcb22a31a100080ffbf7edbac538b1517d99fa85ec77bfac089ab8249e2708") > -1
@@ -443,7 +443,8 @@ def test_integration_transaction_evaluate_cbor():
         # }
 
         # Response with an ogmios error about missing input
-        assert result.result.EvaluationFailure.CannotCreateEvaluationContext.reason.find(
+        script_failure = getattr(result.result.EvaluationFailure.ScriptFailures, 'spend:0')
+        assert script_failure.CannotCreateEvaluationContext.reason.find(
             'Unknown transaction input') > -1
 
 


### PR DESCRIPTION
Update the SDK to match all API changes since v0.1.37, including:

- Accounts: account_utxos (v0.1.69), account_transactions (v0.1.82)
- Blocks: block_latest_transactions_cbor (v0.1.74), block_transactions_cbor (v0.1.75)
- Transactions: transaction_required_signers (v0.1.61), transaction_cbor (v0.1.64)
- Network: network_eras (v0.1.46)
- Governance (new): Full Conway-era governance support with DRep and proposal endpoints including dreps listing, drep details, delegators, metadata, updates, votes, proposals listing, proposal details, parameters, withdrawals, votes, and metadata
- Pools: pool_votes
- Governance proposals by GovActionID (CIP-0129): proposal details, parameters, withdrawals, votes, metadata
- Fix: update all 104 docs URLs to new working format
- Update CI workflows (actions/checkout@v4, actions/setup-python@v5, Python 3.10/3.12/3.13)
- Integration tests fixed
- README.md typo fixed

Bump version to 0.7.0 (API v0.1.86).
All tests pass.